### PR TITLE
Make authentication optional and fix nil pointer dereference

### DIFF
--- a/internal/provider/database_resource.go
+++ b/internal/provider/database_resource.go
@@ -447,7 +447,7 @@ func (r *DatabaseResource) updateStateWithComputedValues(ctx context.Context, st
 	state.Tier = types.StringValue(*databaseModel.Tier)
 
 	propertiesValue := map[string]attr.Value{
-		"archive_disk_size": types.StringValue(*databaseModel.Properties.ArchiveDiskSize),
+		"archive_disk_size": types.StringPointerValue(databaseModel.Properties.ArchiveDiskSize),
 		"journal_disk_size": types.StringPointerValue(databaseModel.Properties.JournalDiskSize),
 		"tier_parameters":   types.MapNull(types.StringType),
 	}


### PR DESCRIPTION
- Remove a bunch of validation that seems to be dead code.
- Do not force the user to provide authentication credentials. It is possible that the server does not require authentication either because it is unsecured or because it allows users on the same host to bypass authentication. Both of these are valid and useful configurations for testing, and should be supported by the provider.
- Fix a nil pointer dereference on the archive disk size.