### PR TITLE
Remove organization from provider config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,19 @@
 version: 2.1
+
 orbs:
   go: circleci/go@1.7.3
+
+executors:
+  java:
+    # Check https://circleci.com/developer/images/image/cimg/openjdk for more details
+    docker:
+      - image: cimg/openjdk:11.0
+    resource_class: small
+
+  ubuntu_vm:
+    machine:
+      image: ubuntu-2204:2023.10.1
+    resource_class: medium
 
 commands:
   run_tests:
@@ -24,9 +37,7 @@ commands:
 
 jobs:
   e2e_tests:
-    machine:
-      image: ubuntu-2204:2023.10.1
-    resource_class: medium
+    executor: ubuntu_vm
     environment:
       E2E_TEST: "true"
       MINIKUBE_VERSION: "1.32.0"
@@ -36,15 +47,17 @@ jobs:
       OUTPUT_DIR: /tmp/service-logs
     steps:
       - run_tests
+
   integration_tests:
-    machine:
-      image: ubuntu-2204:2023.10.1
+    executor: java
     resource_class: medium
     environment:
       KUBERNETES_VERSION: "1.28.3"
       TEST_RESULTS: /tmp/test-results
       OUTPUT_DIR: /tmp/service-logs
     steps:
+      - go/install:
+          version: "1.20"
       - run_tests
 
 workflows:

--- a/Makefile
+++ b/Makefile
@@ -118,14 +118,13 @@ extract-creds: ## Extract and print environment variables for use with running C
 						$(shell kubectl get service $(HELM_NGINX_RELEASE)-controller -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')))
 	$(eval PORT := $(shell kubectl get service $(HELM_NGINX_RELEASE)-controller -o jsonpath='{.spec.ports[?(@.appProtocol=="http")].port}'))
 
+	@echo "export NUODB_CP_USER=system/admin"
 	@echo "export NUODB_CP_PASSWORD=\"$(shell kubectl get secret dbaas-user-system-admin -o jsonpath='{.data.password}' | base64 -d)\""
 	@echo "export NUODB_CP_URL_BASE=\"http://$(HOST):$(PORT)/nuodb-cp\""
-	@echo "export NUODB_CP_USER=admin"
-	@echo "export NUODB_CP_ORGANIZATION=system"
 
 .PHONY: testacc
 testacc: $(GOTESTSUM_BIN) ## Run acceptance tests
-	TF_ACC=1 $(GOTESTSUM_BIN) --junitfile $(TEST_RESULTS)/gotestsum-report.xml --format testname -- -v -timeout 30m $(TESTARGS) ./...
+	TF_ACC=1 $(GOTESTSUM_BIN) --junitfile $(TEST_RESULTS)/gotestsum-report.xml --format testname -- -v -count=1 -timeout 30m $(TESTARGS) ./...
 
 ##@ Build
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Ensure that you have a CSI driver configured.
     make testacc
     ```
 
-    The `extract-creds` target extracts the credentials for the `system/admin` user from the Kubernetes cluster and prints them to standard output. If you want to manually configure the Control Plane instance, set  `NUODB_CP_URL_BASE`, `NUODB_CP_ORGANIZATION`, `NUODB_CP_USER`, and `NUODB_CP_PASSWORD` environment variables and run:
+    The `extract-creds` target extracts the credentials for the `system/admin` user from the Kubernetes cluster and prints them to standard output. If you want to manually configure the Control Plane instance, set  `NUODB_CP_URL_BASE`, `NUODB_CP_USER`, and `NUODB_CP_PASSWORD` environment variables and run:
 
     ```sh
     make testacc

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,8 +50,7 @@ resource "nuodbaas_database" "nuodb" {
 
 ### Optional
 
-- `organization` (String) The Control Plane organization that the user belongs to. If not specified, defaults to the NUODB_CP_ORGANIZATION environment variable.
 - `password` (String, Sensitive) The password for the user. If not specified, defaults to the NUODB_CP_PASSWORD environment variable.
 - `skip_verify` (Boolean) Whether to skip server certificate verification
-- `url_base` (String) The base URL for the server, including the protocol. If not specified, defaults to the NUODB_CP_PASSWORD environment variable.
-- `username` (String) The name of the user. If not specified, defaults to the NUODB_CP_USER environment variable.
+- `url_base` (String) The base URL for the server, including the protocol. If not specified, defaults to the NUODB_CP_URL_BASE environment variable.
+- `user` (String) The name of the user in the format `<organization>/<user>`. If not specified, defaults to the NUODB_CP_USER environment variable.

--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -7,7 +7,6 @@ package provider
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -15,7 +14,7 @@ import (
 func TestAccDatabaseResource(t *testing.T) {
 	projConfig := providerConfig + `
 	resource "nuodbaas_project" "proj" {
-		organization = var.org_name
+		organization = "org"
 		name         = "proj"
 		sla          = "dev"
 		tier         = "n0.nano"
@@ -30,16 +29,15 @@ func TestAccDatabaseResource(t *testing.T) {
 				// Create a project
 				Config: projConfig + `
 				resource "nuodbaas_database" "db" {
-					organization = var.org_name
+					organization = nuodbaas_project.proj.organization
 					project      = nuodbaas_project.proj.name
 					name         = "db"
 					dba_password = "changeMe"
 				}
 				`,
-				ConfigVariables: config.Variables{"org_name": config.StringVariable(testOrgName)},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// TODO: Test that the resources match what is in the REST service
-					resource.TestCheckResourceAttr("nuodbaas_database.db", "organization", testOrgName),
+					resource.TestCheckResourceAttr("nuodbaas_database.db", "organization", "org"),
 					resource.TestCheckResourceAttr("nuodbaas_database.db", "name", "db"),
 					resource.TestCheckResourceAttr("nuodbaas_database.db", "project", "proj"),
 					resource.TestCheckResourceAttr("nuodbaas_database.db", "dba_password", "changeMe"),
@@ -52,7 +50,7 @@ func TestAccDatabaseResource(t *testing.T) {
 				RefreshState: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// TODO: Test that the resources match what is in the REST service
-					resource.TestCheckResourceAttr("nuodbaas_database.db", "organization", testOrgName),
+					resource.TestCheckResourceAttr("nuodbaas_database.db", "organization", "org"),
 					resource.TestCheckResourceAttr("nuodbaas_database.db", "name", "db"),
 					resource.TestCheckResourceAttr("nuodbaas_database.db", "project", "proj"),
 					resource.TestCheckResourceAttr("nuodbaas_database.db", "dba_password", "changeMe"),
@@ -62,7 +60,6 @@ func TestAccDatabaseResource(t *testing.T) {
 			},
 			{
 				// Import it
-				ConfigVariables:         config.Variables{"org_name": config.StringVariable(testOrgName)},
 				ResourceName:            "nuodbaas_database.db",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -73,7 +70,7 @@ func TestAccDatabaseResource(t *testing.T) {
 				// Update the database by setting it to be disabled
 				Config: projConfig + `
 				resource "nuodbaas_database" "db" {
-					organization = var.org_name
+					organization = nuodbaas_project.proj.organization
 					project      = nuodbaas_project.proj.name
 					name         = "db"
 					dba_password = "changeMe"
@@ -82,7 +79,6 @@ func TestAccDatabaseResource(t *testing.T) {
 					}
 				}
 				`,
-				ConfigVariables: config.Variables{"org_name": config.StringVariable(testOrgName)},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// TODO: Test that the resources match what is in the REST service
 					resource.TestCheckResourceAttr("nuodbaas_database.db", "maintenance.is_disabled", "true"),

--- a/internal/provider/project_resource_test.go
+++ b/internal/provider/project_resource_test.go
@@ -7,7 +7,6 @@ package provider
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -21,16 +20,15 @@ func TestAccProjectResource(t *testing.T) {
 				// Create a project
 				Config: providerConfig + `
 					resource "nuodbaas_project" "proj" {
-						organization = var.org_name
+						organization = "org"
 						name         = "proj"
 						sla          = "dev"
 						tier         = "n0.nano"
 					}
 				`,
-				ConfigVariables: config.Variables{"org_name": config.StringVariable(testOrgName)},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// TODO: Test that the resources match what is in the REST service
-					resource.TestCheckResourceAttr("nuodbaas_project.proj", "organization", testOrgName),
+					resource.TestCheckResourceAttr("nuodbaas_project.proj", "organization", "org"),
 					resource.TestCheckResourceAttr("nuodbaas_project.proj", "name", "proj"),
 					resource.TestCheckResourceAttr("nuodbaas_project.proj", "sla", "dev"),
 					resource.TestCheckResourceAttr("nuodbaas_project.proj", "tier", "n0.nano"),
@@ -41,7 +39,7 @@ func TestAccProjectResource(t *testing.T) {
 				// Test that we can read it back
 				RefreshState: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("nuodbaas_project.proj", "organization", testOrgName),
+					resource.TestCheckResourceAttr("nuodbaas_project.proj", "organization", "org"),
 					resource.TestCheckResourceAttr("nuodbaas_project.proj", "name", "proj"),
 					resource.TestCheckResourceAttr("nuodbaas_project.proj", "sla", "dev"),
 					resource.TestCheckResourceAttr("nuodbaas_project.proj", "tier", "n0.nano"),
@@ -50,7 +48,6 @@ func TestAccProjectResource(t *testing.T) {
 			},
 			{
 				// Import it
-				ConfigVariables:         config.Variables{"org_name": config.StringVariable(testOrgName)},
 				ResourceName:            "nuodbaas_project.proj",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -61,7 +58,7 @@ func TestAccProjectResource(t *testing.T) {
 				// Update the project by setting it to be disabled
 				Config: providerConfig + `
 				resource "nuodbaas_project" "proj" {
-					organization = var.org_name
+					organization = "org"
 					name         = "proj"
 					sla          = "dev"
 					tier         = "n0.nano"
@@ -70,7 +67,6 @@ func TestAccProjectResource(t *testing.T) {
 					}
 				}
 				`,
-				ConfigVariables: config.Variables{"org_name": config.StringVariable(testOrgName)},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// TODO: Test that the resources match what is in the REST service
 					resource.TestCheckResourceAttr("nuodbaas_project.proj", "maintenance.is_disabled", "true"),

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -5,7 +5,6 @@ All Rights Reserved.
 package provider
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -14,10 +13,6 @@ import (
 
 const (
 	providerConfig = `
-		variable "org_name" {
-			description = "The name of the organization for the user"
-			type        = string
-		}
 		provider "nuodbaas" { }
   `
 )
@@ -28,20 +23,6 @@ const (
 // reattach.
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
 	"nuodbaas": providerserver.NewProtocol6WithError(New("test")()),
-}
-
-var testOrgName = getOrganization()
-
-// TODO: The tests seem to rely on the organization name being resolved from the
-// environment. Not sure why this is a requirement, but for now, just use the
-// environment variable if it is set and otherwise return an arbitrary
-// organization name.
-func getOrganization() string {
-	org := os.Getenv("NUODB_CP_ORGANIZATION")
-	if org != "" {
-		return org
-	}
-	return "org"
 }
 
 func testAccPreCheck(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ import (
 var (
 	// these will be set by the goreleaser configuration
 	// to appropriate values for the compiled binary.
-	version string = "dev"
+	version string = "0.1.0"
 
 	// goreleaser can pass other information to the main package, such as the specific commit
 	// https://goreleaser.com/cookbooks/using-main.version/


### PR DESCRIPTION
This change removes organization (NUODB_CP_ORGANIZATION) from the provider config. The only reason why the provider config required the organization is to create the user name, which is simply `<organization>/<user>`.

This served no purpose as a separate field and resulted in inconsistencies between the provider and the nuodb-cp tool in how NUODB_CP_USER is interpreted. nuodb-cp treats NUODB_CP_USER as the complete user name (`<organization>/<user>`), so the same set of environment variables would not work with both nuodb-cp and Terraform.

This change also removes the authentication check in the provider, which does not serve any purpose since the same authentication credentials are sent with every request. If the authentication credentials are invalid, then REST request to inspect or manipulate the project or database resource will fail.

This change also uses the Docker executor for the integration tests to reduce resource usage.