### PR TITLE
Add label filter to list data sources

### DIFF
--- a/docs/data-sources/database.md
+++ b/docs/data-sources/database.md
@@ -3,12 +3,12 @@
 page_title: "nuodbaas_database Data Source - nuodbaas"
 subcategory: ""
 description: |-
-  Data source for exposing information about NuoDB databases provisioned using the DBaaS Control Plane
+  Data source for exposing information about NuoDB databases created using the DBaaS Control Plane
 ---
 
 # nuodbaas_database (Data Source)
 
-Data source for exposing information about NuoDB databases provisioned using the DBaaS Control Plane
+Data source for exposing information about NuoDB databases created using the DBaaS Control Plane
 
 ## Example Usage
 

--- a/docs/data-sources/databases.md
+++ b/docs/data-sources/databases.md
@@ -3,12 +3,12 @@
 page_title: "nuodbaas_databases Data Source - nuodbaas"
 subcategory: ""
 description: |-
-  Data source for listing NuoDB databases provisioned using the DBaaS Control Plane
+  Data source for listing NuoDB databases created using the DBaaS Control Plane
 ---
 
 # nuodbaas_databases (Data Source)
 
-Data source for listing NuoDB databases provisioned using the DBaaS Control Plane
+Data source for listing NuoDB databases created using the DBaaS Control Plane
 
 ## Example Usage
 
@@ -19,14 +19,14 @@ data "nuodbaas_databases" "database_list" {}
 
 # Get all databases in a given organization
 data "nuodbaas_databases" "org_database_list" {
-  filter {
+  filter = {
     organization = "system"
   }
 }
 
 # Get all databases in a given project
 data "nuodbaas_databases" "proj_database_list" {
-  filter {
+  filter = {
     organization = "system"
     project      = "nuodb"
   }
@@ -38,19 +38,24 @@ data "nuodbaas_databases" "proj_database_list" {
 
 ### Optional
 
-- `filter` (Block, Optional) Filters to apply to database list (see [below for nested schema](#nestedblock--filter))
+- `filter` (Attributes) Filters to apply to databases (see [below for nested schema](#nestedatt--filter))
 
 ### Read-Only
 
 - `databases` (Attributes List) The list of databases that satisfy the filter requirements (see [below for nested schema](#nestedatt--databases))
 
-<a id="nestedblock--filter"></a>
+<a id="nestedatt--filter"></a>
 ### Nested Schema for `filter`
 
 Optional:
 
-- `organization` (String) The organization to return databases for
-- `project` (String) The project to return databases for. If specified, the organization must also be specified.
+- `labels` (List of String) List of filters to apply based on labels, which are composed using `AND`. Acceptable filter expressions are:
+  * `key` - Only return items that have label with specified key
+  * `key=value` - Only return items that have label with specified key set to value
+  * `!key` - Only return items that do _not_ have label with specified key
+  * `key!=value` - Only return items that do _not_ have label with specified key set to value
+- `organization` (String) The organization to filter databases on
+- `project` (String) The project to filter databases on. If specified, the organization must also be specified.
 
 
 <a id="nestedatt--databases"></a>
@@ -59,5 +64,5 @@ Optional:
 Read-Only:
 
 - `name` (String) The name of the database
-- `organization` (String) The organization that the database belongs to
-- `project` (String) The project that the database belongs to
+- `organization` (String) The organization the database belongs to
+- `project` (String) The project the database belongs to

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -3,12 +3,12 @@
 page_title: "nuodbaas_project Data Source - nuodbaas"
 subcategory: ""
 description: |-
-  Data source for exposing information about NuoDB projects provisioned using the DBaaS Control Plane
+  Data source for exposing information about NuoDB projects created using the DBaaS Control Plane
 ---
 
 # nuodbaas_project (Data Source)
 
-Data source for exposing information about NuoDB projects provisioned using the DBaaS Control Plane
+Data source for exposing information about NuoDB projects created using the DBaaS Control Plane
 
 ## Example Usage
 

--- a/docs/data-sources/projects.md
+++ b/docs/data-sources/projects.md
@@ -3,12 +3,12 @@
 page_title: "nuodbaas_projects Data Source - nuodbaas"
 subcategory: ""
 description: |-
-  Data source for listing NuoDB projects provisioned using the DBaaS Control Plane
+  Data source for listing NuoDB projects created using the DBaaS Control Plane
 ---
 
 # nuodbaas_projects (Data Source)
 
-Data source for listing NuoDB projects provisioned using the DBaaS Control Plane
+Data source for listing NuoDB projects created using the DBaaS Control Plane
 
 ## Example Usage
 
@@ -18,7 +18,7 @@ data "nuodbaas_projects" "projects_list" {}
 
 # Get all projects in a given organization
 data "nuodbaas_projects" "org_projects_list" {
-  filter {
+  filter = {
     organization = "system"
   }
 }
@@ -29,18 +29,23 @@ data "nuodbaas_projects" "org_projects_list" {
 
 ### Optional
 
-- `filter` (Block, Optional) Filters to apply to project list (see [below for nested schema](#nestedblock--filter))
+- `filter` (Attributes) Filters to apply to projects (see [below for nested schema](#nestedatt--filter))
 
 ### Read-Only
 
 - `projects` (Attributes List) The list of projects that satisfy the filter requirements (see [below for nested schema](#nestedatt--projects))
 
-<a id="nestedblock--filter"></a>
+<a id="nestedatt--filter"></a>
 ### Nested Schema for `filter`
 
 Optional:
 
-- `organization` (String) The organization to return projects for
+- `labels` (List of String) List of filters to apply based on labels, which are composed using `AND`. Acceptable filter expressions are:
+  * `key` - Only return items that have label with specified key
+  * `key=value` - Only return items that have label with specified key set to value
+  * `!key` - Only return items that do _not_ have label with specified key
+  * `key!=value` - Only return items that do _not_ have label with specified key set to value
+- `organization` (String) The organization to filter projects on
 
 
 <a id="nestedatt--projects"></a>
@@ -49,4 +54,4 @@ Optional:
 Read-Only:
 
 - `name` (String) The name of the project
-- `organization` (String) The name of the organization the project belongs to
+- `organization` (String) The organization the project belongs to

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -3,12 +3,12 @@
 page_title: "nuodbaas_database Resource - nuodbaas"
 subcategory: ""
 description: |-
-  Resource for managing NuoDB databases provisioned using the DBaaS Control Plane
+  Resource for managing NuoDB databases created using the DBaaS Control Plane
 ---
 
 # nuodbaas_database (Resource)
 
-Resource for managing NuoDB databases provisioned using the DBaaS Control Plane
+Resource for managing NuoDB databases created using the DBaaS Control Plane
 
 ## Example Usage
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -3,12 +3,12 @@
 page_title: "nuodbaas_project Resource - nuodbaas"
 subcategory: ""
 description: |-
-  Resource for managing NuoDB projects provisioned using the DBaaS Control Plane
+  Resource for managing NuoDB projects created using the DBaaS Control Plane
 ---
 
 # nuodbaas_project (Resource)
 
-Resource for managing NuoDB projects provisioned using the DBaaS Control Plane
+Resource for managing NuoDB projects created using the DBaaS Control Plane
 
 ## Example Usage
 

--- a/examples/data-sources/nuodbaas_databases/data-source.tf
+++ b/examples/data-sources/nuodbaas_databases/data-source.tf
@@ -4,14 +4,14 @@ data "nuodbaas_databases" "database_list" {}
 
 # Get all databases in a given organization
 data "nuodbaas_databases" "org_database_list" {
-  filter {
+  filter = {
     organization = "system"
   }
 }
 
 # Get all databases in a given project
 data "nuodbaas_databases" "proj_database_list" {
-  filter {
+  filter = {
     organization = "system"
     project      = "nuodb"
   }

--- a/examples/data-sources/nuodbaas_projects/data-source.tf
+++ b/examples/data-sources/nuodbaas_projects/data-source.tf
@@ -3,7 +3,7 @@ data "nuodbaas_projects" "projects_list" {}
 
 # Get all projects in a given organization
 data "nuodbaas_projects" "org_projects_list" {
-  filter {
+  filter = {
     organization = "system"
   }
 }

--- a/internal/client/testclient/utils.go
+++ b/internal/client/testclient/utils.go
@@ -179,9 +179,9 @@ func CheckClean() error {
 }
 
 func GetProjects(ctx context.Context, client *openapi.Client) ([]string, error) {
-	return helper.GetProjects(ctx, client, "", true)
+	return helper.GetProjects(ctx, client, "", nil, true)
 }
 
 func GetDatabases(ctx context.Context, client *openapi.Client) ([]string, error) {
-	return helper.GetDatabases(ctx, client, "", "", true)
+	return helper.GetDatabases(ctx, client, "", "", nil, true)
 }

--- a/internal/framework/schema_builder.go
+++ b/internal/framework/schema_builder.go
@@ -1,0 +1,130 @@
+package framework
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type AttributeBuilder struct {
+	attributes map[string]schema.Attribute
+}
+
+func (ab *AttributeBuilder) WithStringAttribute(name, description string, optional bool) *AttributeBuilder {
+	ab.attributes[name] = schema.StringAttribute{
+		Description:         description,
+		MarkdownDescription: description,
+		Optional:            optional,
+		Computed:            !optional,
+	}
+	return ab
+}
+
+func (ab *AttributeBuilder) WithOptionalStringAttribute(name, description string) *AttributeBuilder {
+	return ab.WithStringAttribute(name, description, true)
+}
+
+func (ab *AttributeBuilder) WithComputedStringAttribute(name, description string) *AttributeBuilder {
+	return ab.WithStringAttribute(name, description, false)
+}
+
+func (ab *AttributeBuilder) WithNameAttribute(typeName string) *AttributeBuilder {
+	return ab.WithComputedStringAttribute("name", "The name of the "+typeName)
+}
+
+func (ab *AttributeBuilder) WithStringListAttribute(name, description string) *AttributeBuilder {
+	ab.attributes[name] = schema.ListAttribute{
+		Description:         description,
+		MarkdownDescription: description,
+		ElementType:         types.StringType,
+		Optional:            true,
+	}
+	return ab
+}
+
+func (ab *AttributeBuilder) WithNewNestedAttribute(name, description string) *AttributeBuilder {
+	childAttributes := make(map[string]schema.Attribute)
+	ab.attributes[name] = schema.SingleNestedAttribute{
+		Description:         description,
+		MarkdownDescription: description,
+		Attributes:          childAttributes,
+		Optional:            true,
+	}
+	return &AttributeBuilder{childAttributes}
+}
+
+func (ab *AttributeBuilder) WithNewListNestedAttribute(name, description string) *AttributeBuilder {
+	childAttributes := make(map[string]schema.Attribute)
+	ab.attributes[name] = schema.ListNestedAttribute{
+		Description:         description,
+		MarkdownDescription: description,
+		Computed:            true,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: childAttributes,
+		},
+	}
+	return &AttributeBuilder{childAttributes}
+}
+
+type SchemaBuilder struct {
+	AttributeBuilder
+	description string
+}
+
+func (sb *SchemaBuilder) WithDescription(description string) *SchemaBuilder {
+	sb.description = description
+	return sb
+}
+
+const (
+	LABEL_FILTER_DESCRIPTION = "List of filters to apply based on labels, which are composed using `AND`. Acceptable filter expressions are:\n" +
+		"  * `key` - Only return items that have label with specified key\n" +
+		"  * `key=value` - Only return items that have label with specified key set to value\n" +
+		"  * `!key` - Only return items that do _not_ have label with specified key\n" +
+		"  * `key!=value` - Only return items that do _not_ have label with specified key set to value"
+)
+
+// WithOrganizationScopeFilters attaches common attributes for the filter nested
+// attribute of an organization-scoped resource in DBaaS.
+func (sb *SchemaBuilder) WithOrganizationScopeFilters(typeNamePlural string) *AttributeBuilder {
+	return sb.WithNewNestedAttribute("filter", fmt.Sprintf("Filters to apply to %s", typeNamePlural)).
+		WithStringListAttribute("labels", LABEL_FILTER_DESCRIPTION).
+		WithOptionalStringAttribute("organization", fmt.Sprintf("The organization to filter %s on", typeNamePlural))
+}
+
+// WithProjectScopeFilters attaches schema information for the filter nested
+// attribute of a project-scoped resource in DBaaS.
+func (sb *SchemaBuilder) WithProjectScopeFilters(typeNamePlural string) *AttributeBuilder {
+	return sb.WithOrganizationScopeFilters(typeNamePlural).
+		WithOptionalStringAttribute("project", fmt.Sprintf("The project to filter %s on. If specified, the organization must also be specified.", typeNamePlural))
+}
+
+// WithOrganizationScopeList attaches schema information for the list attribute
+// of the supplied type, which is organization-scoped (e.g. projects).
+func (sb *SchemaBuilder) WithOrganizationScopeList(typeName, typeNamePlural string) *AttributeBuilder {
+	return sb.WithNewListNestedAttribute(typeNamePlural, fmt.Sprintf("The list of %s that satisfy the filter requirements", typeNamePlural)).
+		WithComputedStringAttribute("organization", fmt.Sprintf("The organization the %s belongs to", typeName))
+}
+
+// WithProjectScopeList attaches schema information for the list attribute of
+// the supplied type, which is project-scoped (e.g. databases).
+func (sb *SchemaBuilder) WithProjectScopeList(typeName, typeNamePlural string) *AttributeBuilder {
+	return sb.WithNewListNestedAttribute(typeNamePlural, fmt.Sprintf("The list of %s that satisfy the filter requirements", typeNamePlural)).
+		WithComputedStringAttribute("organization", fmt.Sprintf("The organization the %s belongs to", typeName)).
+		WithComputedStringAttribute("project", fmt.Sprintf("The project the %s belongs to", typeName))
+}
+
+func (sb *SchemaBuilder) Build() *schema.Schema {
+	return &schema.Schema{
+		Description:         sb.description,
+		MarkdownDescription: sb.description,
+		Attributes:          sb.attributes,
+	}
+}
+
+func NewSchemaBuilder() *SchemaBuilder {
+	return &SchemaBuilder{
+		AttributeBuilder: AttributeBuilder{make(map[string]schema.Attribute)},
+	}
+}

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -105,14 +105,17 @@ func DeleteDatabaseByName(ctx context.Context, client *openapi.Client, organizat
 	return ParseResponse(resp, nil)
 }
 
-func GetDatabases(ctx context.Context, client *openapi.Client, organization, project string, listAccessible bool) ([]string, error) {
+func GetDatabases(ctx context.Context, client *openapi.Client, organization, project string, labelFilter *string, listAccessible bool) ([]string, error) {
 	var databases []string
 	if len(organization) == 0 {
 		if len(project) != 0 {
 			return nil, fmt.Errorf("Cannot specify project filter (%s) without organization", project)
 		}
 
-		params := openapi.GetAllDatabasesParams{ListAccessible: &listAccessible}
+		params := openapi.GetAllDatabasesParams{
+			LabelFilter:    labelFilter,
+			ListAccessible: &listAccessible,
+		}
 		resp, err := client.GetAllDatabases(ctx, &params)
 		if err != nil {
 			return nil, err
@@ -124,7 +127,10 @@ func GetDatabases(ctx context.Context, client *openapi.Client, organization, pro
 		}
 		databases = *itemList.Items
 	} else if len(project) == 0 {
-		params := openapi.GetOrganizationDatabasesParams{ListAccessible: &listAccessible}
+		params := openapi.GetOrganizationDatabasesParams{
+			LabelFilter:    labelFilter,
+			ListAccessible: &listAccessible,
+		}
 		resp, err := client.GetOrganizationDatabases(ctx, organization, &params)
 		if err != nil {
 			return nil, err
@@ -138,7 +144,10 @@ func GetDatabases(ctx context.Context, client *openapi.Client, organization, pro
 			databases = append(databases, organization+"/"+db)
 		}
 	} else {
-		params := openapi.GetDatabasesParams{ListAccessible: &listAccessible}
+		params := openapi.GetDatabasesParams{
+			LabelFilter:    labelFilter,
+			ListAccessible: &listAccessible,
+		}
 		resp, err := client.GetDatabases(ctx, organization, project, &params)
 		if err != nil {
 			return nil, err
@@ -171,10 +180,13 @@ func DeleteProjectByName(ctx context.Context, client *openapi.Client, organizati
 	return ParseResponse(resp, nil)
 }
 
-func GetProjects(ctx context.Context, client *openapi.Client, organization string, listAccessible bool) ([]string, error) {
+func GetProjects(ctx context.Context, client *openapi.Client, organization string, labelFilter *string, listAccessible bool) ([]string, error) {
 	var projects []string
 	if len(organization) == 0 {
-		params := openapi.GetAllProjectsParams{ListAccessible: &listAccessible}
+		params := openapi.GetAllProjectsParams{
+			LabelFilter:    labelFilter,
+			ListAccessible: &listAccessible,
+		}
 		resp, err := client.GetAllProjects(ctx, &params)
 		if err != nil {
 			return nil, err
@@ -186,7 +198,10 @@ func GetProjects(ctx context.Context, client *openapi.Client, organization strin
 		}
 		projects = *itemList.Items
 	} else {
-		params := openapi.GetProjectsParams{ListAccessible: &listAccessible}
+		params := openapi.GetProjectsParams{
+			LabelFilter:    labelFilter,
+			ListAccessible: &listAccessible,
+		}
 		resp, err := client.GetProjects(ctx, organization, &params)
 		if err != nil {
 			return nil, err

--- a/internal/provider/database_data_source.go
+++ b/internal/provider/database_data_source.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	_ DataSourceState = &DatabaseResourceModel{}
+	_ framework.DataSourceState = &DatabaseResourceModel{}
 )
 
 type DatabaseDataSourceModel openapi.DatabaseModel
@@ -28,15 +28,15 @@ func (state *DatabaseDataSourceModel) Read(ctx context.Context, client *openapi.
 	return helper.ParseResponse(resp, state)
 }
 
-func NewDatabaseDataSourceState() DataSourceState {
+func NewDatabaseDataSourceState() framework.DataSourceState {
 	return &DatabaseDataSourceModel{}
 }
 
 func NewDatabaseDataSource() datasource.DataSource {
-	return &GenericDataSource{
-		resourceTypeName: "database",
-		description:      "Data source for exposing information about NuoDB databases provisioned using the DBaaS Control Plane",
-		getOpenApiSchema: framework.GetDatabaseDataSourceSchema,
-		build:            NewDatabaseDataSourceState,
+	return &framework.GenericDataSource{
+		TypeName:         "database",
+		Description:      "Data source for exposing information about NuoDB databases created using the DBaaS Control Plane",
+		GetOpenApiSchema: framework.GetDatabaseDataSourceSchema,
+		Build:            NewDatabaseDataSourceState,
 	}
 }

--- a/internal/provider/database_data_source_test.go
+++ b/internal/provider/database_data_source_test.go
@@ -18,24 +18,31 @@ import (
 )
 
 func TestAccDatabaseDataSource(t *testing.T) {
-	organizationName := "org"
-	projectName := "proj"
-	sla := "dev"
-	tier := "n0.nano"
-	dbName := "db"
-
-	password := "pass"
-	archiveDisk := "1Gi"
-	journalDisk := "2Gi"
-	disabled := true
-	tierParamKey := "foo"
-	tierParamValue := "bar"
+	var (
+		organizationName = "org"
+		projectName      = "proj"
+		dbName           = "db"
+		sla              = "dev"
+		tier             = "n0.nano"
+		dbaPassword      = "pass"
+		disabled         = true
+		archiveDisk      = "1Gi"
+		journalDisk      = "2Gi"
+		productVersion   = "5.1"
+		tierParamKey     = "foo"
+		tierParamValue   = "bar"
+	)
 
 	model := openapi.DatabaseCreateUpdateModel{
-		DbaPassword: &password,
+		DbaPassword: &dbaPassword,
+		Labels: &map[string]string{
+			"key0": "value0",
+			"key1": "value1",
+		},
 		Properties: &openapi.DatabasePropertiesModel{
 			ArchiveDiskSize: &archiveDisk,
 			JournalDiskSize: &journalDisk,
+			ProductVersion:  &productVersion,
 			TierParameters:  &map[string]string{tierParamKey: tierParamValue},
 		},
 		Maintenance: &openapi.MaintenanceModel{
@@ -69,13 +76,23 @@ func TestAccDatabaseDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourcePath, "project", projectName),
 					resource.TestCheckResourceAttr(resourcePath, "name", dbName),
 					resource.TestCheckResourceAttr(resourcePath, "tier", tier),
+					resource.TestCheckResourceAttr(resourcePath, "labels.%", "2"),
+					resource.TestCheckResourceAttr(resourcePath, "labels.key0", "value0"),
+					resource.TestCheckResourceAttr(resourcePath, "labels.key1", "value1"),
 					resource.TestCheckResourceAttr(resourcePath, "maintenance.is_disabled", strconv.FormatBool(disabled)),
 					resource.TestCheckResourceAttr(resourcePath, "properties.archive_disk_size", archiveDisk),
 					resource.TestCheckResourceAttr(resourcePath, "properties.journal_disk_size", journalDisk),
+					resource.TestCheckResourceAttr(resourcePath, "properties.product_version", productVersion),
 					resource.TestCheckResourceAttr(resourcePath, "properties.tier_parameters.%", "1"),
 					resource.TestCheckResourceAttr(resourcePath, "properties.tier_parameters."+tierParamKey, tierParamValue),
 					resource.TestCheckResourceAttrSet(resourcePath, "status.sql_endpoint"),
-					// Flaky under envtest
+					resource.TestCheckNoResourceAttr(resourcePath, "dba_password"),
+					resource.TestCheckNoResourceAttr(resourcePath, "resource_version"),
+					// TODO(asz6): This is flaky because the mock controller that simulates the
+					// DBaaS operator sets the database as ready asynchronously with generating the
+					// CA certificate. This makes it is possible for the database to be marked as
+					// ready before the CA PEM is available, which is unrealistic. We can uncomment
+					// this once the mock controller is updated to have more realistic behavior.
 					// resource.TestCheckResourceAttrSet(resourcePath, "status.ca_pem"),
 				),
 			},

--- a/internal/provider/database_resource.go
+++ b/internal/provider/database_resource.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	_ ResourceState = &DatabaseResourceModel{}
+	_ framework.ResourceState = &DatabaseResourceModel{}
 )
 
 type DatabaseResourceModel openapi.DatabaseCreateUpdateModel
@@ -124,15 +124,15 @@ func (state *DatabaseResourceModel) SetId(id string) error {
 	return nil
 }
 
-func NewDatabaseResourceState() ResourceState {
+func NewDatabaseResourceState() framework.ResourceState {
 	return &DatabaseResourceModel{}
 }
 
 func NewDatabaseResource() resource.Resource {
-	return &GenericResource{
-		resourceTypeName: "database",
-		description:      "Resource for managing NuoDB databases provisioned using the DBaaS Control Plane",
-		getOpenApiSchema: framework.GetDatabaseResourceSchema,
-		build:            NewDatabaseResourceState,
+	return &framework.GenericResource{
+		TypeName:         "database",
+		Description:      "Resource for managing NuoDB databases created using the DBaaS Control Plane",
+		GetOpenApiSchema: framework.GetDatabaseResourceSchema,
+		Build:            NewDatabaseResourceState,
 	}
 }

--- a/internal/provider/project_data_source.go
+++ b/internal/provider/project_data_source.go
@@ -10,15 +10,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 )
 
-func NewProjectDataSourceState() DataSourceState {
+func NewProjectDataSourceState() framework.DataSourceState {
 	return &ProjectResourceModel{}
 }
 
 func NewProjectDataSource() datasource.DataSource {
-	return &GenericDataSource{
-		resourceTypeName: "project",
-		description:      "Data source for exposing information about NuoDB projects provisioned using the DBaaS Control Plane",
-		getOpenApiSchema: framework.GetProjectSchema,
-		build:            NewProjectDataSourceState,
+	return &framework.GenericDataSource{
+		TypeName:         "project",
+		Description:      "Data source for exposing information about NuoDB projects created using the DBaaS Control Plane",
+		GetOpenApiSchema: framework.GetProjectSchema,
+		Build:            NewProjectDataSourceState,
 	}
 }

--- a/internal/provider/project_data_source_test.go
+++ b/internal/provider/project_data_source_test.go
@@ -17,22 +17,28 @@ import (
 )
 
 func TestAccProjectDataSource(t *testing.T) {
-	organizationName := "org"
-	projectName := "proj"
-	sla := "dev"
-	tier := "n0.nano"
-
-	disabled := true
-	tierParamKey := "foo"
-	tierParamValue := "bar"
+	var (
+		organizationName = "org"
+		projectName      = "proj"
+		sla              = "dev"
+		tier             = "n0.nano"
+		disabled         = true
+		productVersion   = "6.0"
+		tierParamKey     = "foo"
+		tierParamValue   = "bar"
+	)
 
 	model := openapi.ProjectModel{
 		Sla:  sla,
 		Tier: tier,
+		Labels: &map[string]string{
+			"key": "value",
+		},
 		Maintenance: &openapi.MaintenanceModel{
 			IsDisabled: &disabled,
 		},
 		Properties: &openapi.ProjectPropertiesModel{
+			ProductVersion: &productVersion,
 			TierParameters: &map[string]string{tierParamKey: tierParamValue},
 		},
 	}
@@ -61,7 +67,10 @@ func TestAccProjectDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourcePath, "name", projectName),
 					resource.TestCheckResourceAttr(resourcePath, "sla", sla),
 					resource.TestCheckResourceAttr(resourcePath, "tier", tier),
+					resource.TestCheckResourceAttr(resourcePath, "labels.%", "1"),
+					resource.TestCheckResourceAttr(resourcePath, "labels.key", "value"),
 					resource.TestCheckResourceAttr(resourcePath, "maintenance.is_disabled", "true"),
+					resource.TestCheckResourceAttr(resourcePath, "properties.product_version", "6.0"),
 					resource.TestCheckResourceAttr(resourcePath, "properties.tier_parameters.%", "1"),
 					resource.TestCheckResourceAttr(resourcePath, "properties.tier_parameters."+tierParamKey, tierParamValue),
 				),

--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -17,7 +17,8 @@ import (
 )
 
 var (
-	_ ResourceState = &ProjectResourceModel{}
+	_ framework.ResourceState   = &ProjectResourceModel{}
+	_ framework.DataSourceState = &ProjectResourceModel{}
 )
 
 type ProjectResourceModel openapi.ProjectModel
@@ -111,15 +112,15 @@ func (state *ProjectResourceModel) SetId(id string) error {
 	return nil
 }
 
-func NewProjectResourceModel() ResourceState {
+func NewProjectResourceModel() framework.ResourceState {
 	return &ProjectResourceModel{}
 }
 
 func NewProjectResource() resource.Resource {
-	return &GenericResource{
-		resourceTypeName: "project",
-		description:      "Resource for managing NuoDB projects provisioned using the DBaaS Control Plane",
-		getOpenApiSchema: framework.GetProjectSchema,
-		build:            NewProjectResourceModel,
+	return &framework.GenericResource{
+		TypeName:         "project",
+		Description:      "Resource for managing NuoDB projects created using the DBaaS Control Plane",
+		GetOpenApiSchema: framework.GetProjectSchema,
+		Build:            NewProjectResourceModel,
 	}
 }

--- a/internal/provider/projects_data_source.go
+++ b/internal/provider/projects_data_source.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/nuodb/terraform-provider-nuodbaas/internal/framework"
 	"github.com/nuodb/terraform-provider-nuodbaas/internal/helper"
 	"github.com/nuodb/terraform-provider-nuodbaas/openapi"
 
@@ -17,11 +18,12 @@ import (
 )
 
 var (
-	_ DataSourceState = &ProjectsDataSourceModel{}
+	_ framework.DataSourceState = &ProjectsDataSourceModel{}
 )
 
 type ProjectFilterModel struct {
-	Organization *string `tfsdk:"organization"`
+	Organization *string  `tfsdk:"organization"`
+	Labels       []string `tfsdk:"labels"`
 }
 
 type ProjectNameModel struct {
@@ -38,55 +40,26 @@ type ProjectsDataSourceModel struct {
 // source. This has to be provided explicitly because there is no schema in the
 // OpenAPI spec for the REST API that corresponds to it.
 func GetProjectsDataSourceSchema() *schema.Schema {
-	return &schema.Schema{
-		Description:         "Data source for listing NuoDB projects provisioned using the DBaaS Control Plane",
-		MarkdownDescription: "Data source for listing NuoDB projects provisioned using the DBaaS Control Plane",
-		Attributes: map[string]schema.Attribute{
-			"projects": schema.ListNestedAttribute{
-				Description:         "The list of projects that satisfy the filter requirements",
-				MarkdownDescription: "The list of projects that satisfy the filter requirements",
-				Computed:            true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"organization": schema.StringAttribute{
-							Description:         "The name of the organization the project belongs to",
-							MarkdownDescription: "The name of the organization the project belongs to",
-							Computed:            true,
-						},
-						"name": schema.StringAttribute{
-							Description:         "The name of the project",
-							MarkdownDescription: "The name of the project",
-							Computed:            true,
-						},
-					},
-				},
-			},
-		},
-		Blocks: map[string]schema.Block{
-			"filter": schema.SingleNestedBlock{
-				Description:         "Filters to apply to project list",
-				MarkdownDescription: "Filters to apply to project list",
-				Attributes: map[string]schema.Attribute{
-					"organization": schema.StringAttribute{
-						Description:         "The organization to return projects for",
-						MarkdownDescription: "The organization to return projects for",
-						Optional:            true,
-					},
-				},
-			},
-		},
-	}
+	sb := framework.NewSchemaBuilder().WithDescription("Data source for listing NuoDB projects created using the DBaaS Control Plane")
+	sb.WithOrganizationScopeFilters("projects")
+	sb.WithOrganizationScopeList("project", "projects").WithNameAttribute("project")
+	return sb.Build()
 }
 
 // Read implements datasource.DataSource.
 func (state *ProjectsDataSourceModel) Read(ctx context.Context, client *openapi.Client) error {
 	var organization string
+	var labelFilter *string
 	if state.Filter != nil {
 		if state.Filter.Organization != nil {
 			organization = *state.Filter.Organization
 		}
+		if state.Filter.Labels != nil {
+			labelFilterStr := strings.Join(state.Filter.Labels, ",")
+			labelFilter = &labelFilterStr
+		}
 	}
-	projects, err := helper.GetProjects(ctx, client, organization, true)
+	projects, err := helper.GetProjects(ctx, client, organization, labelFilter, true)
 	if err != nil {
 		return err
 	}
@@ -109,14 +82,14 @@ func GetProjectDataSourceResponse(projects []string) ([]ProjectNameModel, error)
 	return ret, nil
 }
 
-func NewProjectsDataSourceState() DataSourceState {
+func NewProjectsDataSourceState() framework.DataSourceState {
 	return &ProjectsDataSourceModel{}
 }
 
 func NewProjectsDataSource() datasource.DataSource {
-	return &GenericDataSource{
-		resourceTypeName: "projects",
-		schema:           GetProjectsDataSourceSchema(),
-		build:            NewProjectsDataSourceState,
+	return &framework.GenericDataSource{
+		TypeName:       "projects",
+		SchemaOverride: GetProjectsDataSourceSchema(),
+		Build:          NewProjectsDataSourceState,
 	}
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -6,6 +6,7 @@ package provider
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -46,4 +47,9 @@ func getProviderTypeName() string {
 	instance.Metadata(ctx, provider.MetadataRequest{}, &response)
 
 	return response.TypeName
+}
+
+func IsE2eTest() bool {
+	value, ok := os.LookupEnv("E2E_TEST")
+	return ok && value == "true"
 }

--- a/tools.go
+++ b/tools.go
@@ -6,6 +6,7 @@ All Rights Reserved.
 
 package tools
 
+// List of build tools to fetch using `make install-tools`
 import (
 	_ "github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen"
 	_ "github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs"


### PR DESCRIPTION
- Add label filter to databases and projects (plural) data sources, which causes the labelFilter query parameter to be injected with a comma-separated list of the label constraints when invoking GET.
- Convert the filter block to a nested attribute. Exposing configuration as blocks seems to be a legacy feature and is discouraged in documentation for the Terraform plugin framework.
- Add schema builder that eliminates boilerplate when creating list data sources.
- Make some changes based on PR feedback for #16.
- Adding some test coverage of the attributes that were introduced by #16 and of the label filtering.