### PR TITLE
Update state after resource is ready

### DIFF
--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -42,6 +42,8 @@ func TestAccDatabaseResource(t *testing.T) {
 					resource.TestCheckResourceAttr("nuodbaas_database.db", "dba_password", "changeMe"),
 					// Tier is inherited from project
 					resource.TestCheckResourceAttr("nuodbaas_database.db", "tier", "n0.nano"),
+					// The create operation should block until the state is Available
+					resource.TestCheckResourceAttr("nuodbaas_database.db", "status.state", "Available"),
 				),
 			},
 			{
@@ -54,6 +56,7 @@ func TestAccDatabaseResource(t *testing.T) {
 					resource.TestCheckResourceAttr("nuodbaas_database.db", "project", "proj"),
 					resource.TestCheckResourceAttr("nuodbaas_database.db", "dba_password", "changeMe"),
 					resource.TestCheckResourceAttr("nuodbaas_database.db", "tier", "n0.nano"),
+					resource.TestCheckResourceAttr("nuodbaas_database.db", "status.state", "Available"),
 				),
 			},
 			{
@@ -97,6 +100,8 @@ func TestAccDatabaseResource(t *testing.T) {
 					resource.TestCheckResourceAttr("nuodbaas_database.db", "labels.foo", "bar"),
 					resource.TestCheckResourceAttr("nuodbaas_database.db", "maintenance.is_disabled", "true"),
 					resource.TestCheckResourceAttr("nuodbaas_database.db", "properties.product_version", "9.9.9"),
+					// The update operation should block until the state is Stopped when is_disabled=true
+					resource.TestCheckResourceAttr("nuodbaas_database.db", "status.state", "Stopped"),
 				),
 			},
 		},

--- a/internal/provider/project_resource_test.go
+++ b/internal/provider/project_resource_test.go
@@ -37,6 +37,8 @@ func TestAccProjectResource(t *testing.T) {
 					resource.TestCheckResourceAttr("nuodbaas_project.proj", "labels.key", "value"),
 					// product_version should be computed by the REST service
 					resource.TestCheckResourceAttrSet("nuodbaas_project.proj", "properties.product_version"),
+					// The create operation should block until the state is Available
+					resource.TestCheckResourceAttr("nuodbaas_project.proj", "status.state", "Available"),
 				),
 			},
 			{
@@ -49,8 +51,8 @@ func TestAccProjectResource(t *testing.T) {
 					resource.TestCheckResourceAttr("nuodbaas_project.proj", "tier", "n0.nano"),
 					resource.TestCheckResourceAttr("nuodbaas_project.proj", "labels.%", "1"),
 					resource.TestCheckResourceAttr("nuodbaas_project.proj", "labels.key", "value"),
-					// product_version should be computed by the REST service
 					resource.TestCheckResourceAttrSet("nuodbaas_project.proj", "properties.product_version"),
+					resource.TestCheckResourceAttr("nuodbaas_project.proj", "status.state", "Available"),
 				),
 			},
 			{
@@ -91,6 +93,8 @@ func TestAccProjectResource(t *testing.T) {
 					// Check updated attribute values
 					resource.TestCheckResourceAttr("nuodbaas_project.proj", "maintenance.is_disabled", "true"),
 					resource.TestCheckResourceAttr("nuodbaas_project.proj", "properties.product_version", "9.9.9"),
+					// The update operation should block until the state is Stopped when is_disabled=true
+					resource.TestCheckResourceAttr("nuodbaas_project.proj", "status.state", "Stopped"),
 				),
 			},
 			{
@@ -115,6 +119,7 @@ func TestAccProjectResource(t *testing.T) {
 					// Maintenance setting and properties should remain due to them being computed / UseStateForUnknown
 					resource.TestCheckResourceAttr("nuodbaas_project.proj", "maintenance.is_disabled", "true"),
 					resource.TestCheckResourceAttr("nuodbaas_project.proj", "properties.product_version", "9.9.9"),
+					resource.TestCheckResourceAttr("nuodbaas_project.proj", "status.state", "Stopped"),
 				),
 			},
 			{


### PR DESCRIPTION
This change performs an update of the Terraform state after the readiness check for create or update completes, so that the latest state retrieved from the server is available. Previously we were only updating the state before the polling loop where we await readiness, which is necessary so that we can still manage the resource if the polling loop times out, but this would leave stale state in Terraform.