### PR TITLE
Add CircleCI job to check generated code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,12 @@ orbs:
   go: circleci/go@1.7.3
 
 executors:
+  go:
+    # Check https://circleci.com/developer/images/image/cimg/go for more details
+    docker:
+      - image: cimg/go:1.22.0
+    resource_class: small
+
   java:
     # Check https://circleci.com/developer/images/image/cimg/openjdk for more details
     docker:
@@ -27,10 +33,13 @@ commands:
       - run:
           name: "Run tests"
           command: "make testacc"
+      - run:
+          name: "Generate coverage report"
+          command: "make coverage-report"
       - store_artifacts:
-          name: "Upload log output from services"
-          path: /tmp/service-logs
-          destination: service-logs
+          name: "Upload test artifacts"
+          path: /tmp/test-artifacts
+          destination: test-artifacts
       - store_test_results:
           name: "Upload test results"
           path: /tmp/test-results
@@ -44,25 +53,36 @@ jobs:
       HELM_VERSION: "v3.14.0"
       KUBERNETES_VERSION: "1.28.3"
       TEST_RESULTS: /tmp/test-results
-      OUTPUT_DIR: /tmp/service-logs
+      OUTPUT_DIR: /tmp/test-artifacts
       TESTARGS: "-short"
     steps:
       - run_tests
 
   integration_tests:
     executor: java
-    resource_class: medium
     environment:
       KUBERNETES_VERSION: "1.28.3"
       TEST_RESULTS: /tmp/test-results
-      OUTPUT_DIR: /tmp/service-logs
+      OUTPUT_DIR: /tmp/test-artifacts
     steps:
       - go/install:
           version: "1.20"
       - run_tests
+
+  check_generated:
+    executor: go
+    steps:
+      - checkout
+      - run:
+          name: "Generate OpenAPI client and Terraform provider documentation"
+          command: make generate
+      - run:
+          name: "Check that there are no generated changes"
+          command: make check-no-changes
 
 workflows:
   test:
     jobs:
       - e2e_tests
       - integration_tests
+      - check_generated

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -30,12 +30,8 @@ if [ "$E2E_TEST" = true ]; then
     # Extract credentials and make them available as environment variables for subsequent steps in job
     make extract-creds >> "$BASH_ENV"
 else
-    # Download test helper for REST service that includes CRUD-only K8s and mock operators
-    curl -Lo test-helper.tgz https://github.com/nuodb/nuodb-cp-releases/releases/download/test-helper/test-helper.tgz
-    tar -xf test-helper.tgz
-
-    # Start K8s, mock operators, and REST service
-    MARK_AS_READY=true ./test-helper/setup-rest.sh
+    # Download and start test helper for REST service that includes CRUD-only K8s and mock operators
+    make deploy-test-helper
 
     # Allow kubectl to be used against cluster by subsequent commands if needed
     echo "export KUBECONFIG=\"$OUTPUT_DIR/kubeconfig.yml\"" >> "$BASH_ENV"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 example.tf
 terraform.tfplan
 terraform.tfstate
+tmp/
 bin/
 dist/
 modules-dev/

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 //go:generate bin/oapi-codegen -generate spec -include-tags databases,projects -package openapi -o openapi/spec.go openapi.yaml
 
 // Format Terraform examples:
-//go:generate terraform fmt -recursive ./examples/
+//go:generate bin/terraform fmt -recursive ./examples/
 
 // Generate documentation:
 //go:generate bin/tfplugindocs generate --provider-name nuodbaas


### PR DESCRIPTION
This change adds a CircleCI job that checks that the checked in generated code has not diverged from the checked in sources for the generated code.

This also adds a make target to download, run, and teardown REST integration test helper, and adds reporting of code coverage.