### PR TITLE
Set version to 1.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ OAPI_CODEGEN_BIN := bin/oapi-codegen
 TERRAFORM_BIN := bin/terraform
 KUBECTL_BIN := bin/kubectl
 
-PUBLISH_VERSION ?= 0.2.0
+PUBLISH_VERSION ?= 1.0.0
 PUBLISH_DIR ?= $(PROJECT_DIR)/dist
 
 IGNORE_NOT_FOUND ?= true

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     nuodbaas = {
       source  = "registry.terraform.io/nuodb/nuodbaas"
-      version = "0.2.0"
+      version = "1.0.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     nuodbaas = {
       source  = "registry.terraform.io/nuodb/nuodbaas"
-      version = "0.2.0"
+      version = "1.0.0"
     }
   }
 }

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ import (
 var (
 	// these will be set by the goreleaser configuration
 	// to appropriate values for the compiled binary.
-	version string = "0.2.0"
+	version string = "1.0.0"
 
 	// goreleaser can pass other information to the main package, such as the specific commit
 	// https://goreleaser.com/cookbooks/using-main.version/

--- a/test/app/providers.tf
+++ b/test/app/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     nuodbaas = {
       source  = "registry.terraform.io/nuodb/nuodbaas"
-      version = "0.2.0"
+      version = "1.0.0"
     }
     docker = {
       source  = "kreuzwerker/docker"


### PR DESCRIPTION
This change sets the version of the provider to 1.0.0 in preparation for the initial GA release.