### PR TITLE
Randomize project name in app test to avoid collisions

### DIFF
--- a/test/app/nuodb.tf
+++ b/test/app/nuodb.tf
@@ -1,6 +1,12 @@
+# Generate a random suffix to avoid collisions
+resource "random_integer" "suffix" {
+  min = 1000
+  max = 9999
+}
+
 resource "nuodbaas_project" "test" {
   organization = var.org_name
-  name         = var.project_name
+  name         = "${var.project_name}${random_integer.suffix.id}"
   sla          = "test"
   tier         = "n0.nano"
 }

--- a/test/app/providers.tf
+++ b/test/app/providers.tf
@@ -8,8 +8,15 @@ terraform {
       source  = "kreuzwerker/docker"
       version = "3.0.2"
     }
+    random = {
+      source = "hashicorp/random"
+      version = "3.6.0"
+    }
   }
 }
+
+# Used to generate unique project name to avoid collisions
+provider "random" { }
 
 provider "docker" { }
 


### PR DESCRIPTION
This change randomizes the project name so that collisions do not occur if two tests runs execute concurrently.