### PR TITLE
Allow development versions of OpenAPI spec to be used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,9 +155,15 @@ check-no-changes: ## Check that there are no uncommitted changes
 	@[ "$(GIT_STATUS)" = "" ] || ( echo "There are uncommitted changes:\n$(GIT_STATUS)"; exit 1; )
 
 .PHONY: generate
-generate: $(TFPLUGINDOCS_BIN) $(OAPI_CODEGEN_BIN) $(TERRAFORM_BIN) ## Generate Golang client for the NuoDB REST API and Terraform provider documentation
-	curl -s https://raw.githubusercontent.com/nuodb/nuodb-cp-releases/v$(CP_VERSION)/openapi.yaml -o openapi.yaml
+generate: $(TFPLUGINDOCS_BIN) $(OAPI_CODEGEN_BIN) $(TERRAFORM_BIN) update-spec ## Generate Golang client for the NuoDB REST API and Terraform provider documentation
 	go generate
+
+.PHONY: update-spec
+update-spec: ## Update spec to released Control Plane version
+	@if git tag --points-at HEAD | grep -q "^v"; then \
+		echo "Updating openapi.yaml because commit has version tag..." ;\
+		curl -s https://raw.githubusercontent.com/nuodb/nuodb-cp-releases/v$(CP_VERSION)/openapi.yaml -o openapi.yaml ;\
+	fi
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT_BIN) ## Run linters to check code quality and find for common errors

--- a/Makefile
+++ b/Makefile
@@ -155,15 +155,16 @@ check-no-changes: ## Check that there are no uncommitted changes
 	@[ "$(GIT_STATUS)" = "" ] || ( echo "There are uncommitted changes:\n$(GIT_STATUS)"; exit 1; )
 
 .PHONY: generate
-generate: $(TFPLUGINDOCS_BIN) $(OAPI_CODEGEN_BIN) $(TERRAFORM_BIN) update-spec ## Generate Golang client for the NuoDB REST API and Terraform provider documentation
+generate: $(TFPLUGINDOCS_BIN) $(OAPI_CODEGEN_BIN) $(TERRAFORM_BIN) ## Generate Golang client for the NuoDB REST API and Terraform provider documentation
+	@if git tag --points-at HEAD | grep -q "^v"; then \
+		echo "Updating openapi.yaml because commit has version tag..." ;\
+		make update-spec ;\
+	fi
 	go generate
 
 .PHONY: update-spec
 update-spec: ## Update spec to released Control Plane version
-	@if git tag --points-at HEAD | grep -q "^v"; then \
-		echo "Updating openapi.yaml because commit has version tag..." ;\
-		curl -s https://raw.githubusercontent.com/nuodb/nuodb-cp-releases/v$(CP_VERSION)/openapi.yaml -o openapi.yaml ;\
-	fi
+	curl -s https://raw.githubusercontent.com/nuodb/nuodb-cp-releases/v$(CP_VERSION)/openapi.yaml -o openapi.yaml
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT_BIN) ## Run linters to check code quality and find for common errors

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ check-no-changes: ## Check that there are no uncommitted changes
 generate: $(TFPLUGINDOCS_BIN) $(OAPI_CODEGEN_BIN) $(TERRAFORM_BIN) ## Generate Golang client for the NuoDB REST API and Terraform provider documentation
 	@if git tag --points-at HEAD | grep -q "^v"; then \
 		echo "Updating openapi.yaml because commit has version tag..." ;\
-		make update-spec ;\
+		$(MAKE) update-spec ;\
 	fi
 	go generate
 

--- a/internal/framework/modifiers.go
+++ b/internal/framework/modifiers.go
@@ -3,7 +3,6 @@
 // This software is licensed under a BSD 3-Clause License.
 // See the LICENSE file provided with this software.
 
-//nolint:forcetypeassert // Type checker cannot track type guarantees in comments
 package framework
 
 import (
@@ -132,7 +131,7 @@ func (m GenericPlanModifier) PlanModifyBool(_ context.Context, req planmodifier.
 	genericResponse := m.createResponse(resp.PlanValue, resp.RequiresReplace, &resp.Diagnostics)
 	m.execute(genericRequest, &genericResponse)
 	resp.RequiresReplace = genericResponse.RequiresReplace
-	resp.PlanValue = genericResponse.PlanValue.(types.Bool)
+	resp.PlanValue, _ = genericResponse.PlanValue.(types.Bool)
 }
 
 // PlanModifyInt64 implements the plan modification logic.
@@ -141,7 +140,7 @@ func (m GenericPlanModifier) PlanModifyInt64(_ context.Context, req planmodifier
 	genericResponse := m.createResponse(resp.PlanValue, resp.RequiresReplace, &resp.Diagnostics)
 	m.execute(genericRequest, &genericResponse)
 	resp.RequiresReplace = genericResponse.RequiresReplace
-	resp.PlanValue = genericResponse.PlanValue.(types.Int64)
+	resp.PlanValue, _ = genericResponse.PlanValue.(types.Int64)
 }
 
 // PlanModifyFloat64 implements the plan modification logic.
@@ -150,7 +149,7 @@ func (m GenericPlanModifier) PlanModifyFloat64(_ context.Context, req planmodifi
 	genericResponse := m.createResponse(resp.PlanValue, resp.RequiresReplace, &resp.Diagnostics)
 	m.execute(genericRequest, &genericResponse)
 	resp.RequiresReplace = genericResponse.RequiresReplace
-	resp.PlanValue = genericResponse.PlanValue.(types.Float64)
+	resp.PlanValue, _ = genericResponse.PlanValue.(types.Float64)
 }
 
 // PlanModifyNumber implements the plan modification logic.
@@ -159,7 +158,7 @@ func (m GenericPlanModifier) PlanModifyNumber(_ context.Context, req planmodifie
 	genericResponse := m.createResponse(resp.PlanValue, resp.RequiresReplace, &resp.Diagnostics)
 	m.execute(genericRequest, &genericResponse)
 	resp.RequiresReplace = genericResponse.RequiresReplace
-	resp.PlanValue = genericResponse.PlanValue.(types.Number)
+	resp.PlanValue, _ = genericResponse.PlanValue.(types.Number)
 }
 
 // PlanModifyString implements the plan modification logic.
@@ -168,7 +167,7 @@ func (m GenericPlanModifier) PlanModifyString(_ context.Context, req planmodifie
 	genericResponse := m.createResponse(resp.PlanValue, resp.RequiresReplace, &resp.Diagnostics)
 	m.execute(genericRequest, &genericResponse)
 	resp.RequiresReplace = genericResponse.RequiresReplace
-	resp.PlanValue = genericResponse.PlanValue.(types.String)
+	resp.PlanValue, _ = genericResponse.PlanValue.(types.String)
 }
 
 // PlanModifyList implements the plan modification logic.
@@ -177,7 +176,7 @@ func (m GenericPlanModifier) PlanModifyList(_ context.Context, req planmodifier.
 	genericResponse := m.createResponse(resp.PlanValue, resp.RequiresReplace, &resp.Diagnostics)
 	m.execute(genericRequest, &genericResponse)
 	resp.RequiresReplace = genericResponse.RequiresReplace
-	resp.PlanValue = genericResponse.PlanValue.(types.List)
+	resp.PlanValue, _ = genericResponse.PlanValue.(types.List)
 }
 
 // PlanModifyMap implements the plan modification logic.
@@ -186,7 +185,7 @@ func (m GenericPlanModifier) PlanModifyMap(_ context.Context, req planmodifier.M
 	genericResponse := m.createResponse(resp.PlanValue, resp.RequiresReplace, &resp.Diagnostics)
 	m.execute(genericRequest, &genericResponse)
 	resp.RequiresReplace = genericResponse.RequiresReplace
-	resp.PlanValue = genericResponse.PlanValue.(types.Map)
+	resp.PlanValue, _ = genericResponse.PlanValue.(types.Map)
 }
 
 // PlanModifyObject implements the plan modification logic.
@@ -195,7 +194,7 @@ func (m GenericPlanModifier) PlanModifyObject(_ context.Context, req planmodifie
 	genericResponse := m.createResponse(resp.PlanValue, resp.RequiresReplace, &resp.Diagnostics)
 	m.execute(genericRequest, &genericResponse)
 	resp.RequiresReplace = genericResponse.RequiresReplace
-	resp.PlanValue = genericResponse.PlanValue.(types.Object)
+	resp.PlanValue, _ = genericResponse.PlanValue.(types.Object)
 }
 
 func useStateForUnknown(req GenericRequest, resp *GenericResponse) {


### PR DESCRIPTION
This change avoids downloading the released version of the OpenAPI spec if the commit is not tagged with a version, allowing us to use development versions of the spec. If commit is tagged, then any differences between the checked in spec and the released spec should cause the goreleaser GitHub Action to fail, because it has a `before` hook that invokes `make generate` followed by `make check-no-changes`.

This change also addresses linter errors having to do with conversion of the values from the typed modifiers from the Terraform library.