### PR TITLE
Check for errors in application e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
     steps:
      - checkout
      - run:
-        name: "Run end to end deplyment test"
+        name: "Run end to end deployment test"
         command: |
           # CircleCI does not like setting variables from variables in the environment section
           export NUODB_CP_USER=$DBAAS_TEST_USER

--- a/test/app/run.sh
+++ b/test/app/run.sh
@@ -32,6 +32,8 @@ check_err() {
     fi
 }
 
+errors=""
+
 # Get organization from user name
 USER_ORG="${NUODB_CP_USER%/*}"
 

--- a/test/app/run.sh
+++ b/test/app/run.sh
@@ -1,15 +1,19 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-cd $( dirname $0 )
+# Build and stage Terraform provider
+cd "$(dirname "$0")"
+WS_ROOT="$(cd ../.. && pwd)"
+make -C "$WS_ROOT" package
 
-WS_ROOT=$( realpath ../.. )
+# Download Terraform binary if necessary
+if [ -z "$TERRAFORM_BIN" ] || [ ! -x "$TERRAFORM_BIN" ]; then
+    make -C "$WS_ROOT" bin/terraform
+    TERRAFORM_BIN="$WS_ROOT/bin/terraform"
+fi
+
+# Set config to use local provider
 export TF_CLI_CONFIG_FILE=./conf.tfrc
-TERRAFORM_BIN_PATH=bin/terraform
-
-make -C $WS_ROOT package $TERRAFORM_BIN_PATH
-: ${TERRAFORM_BIN:=$WS_ROOT/$TERRAFORM_BIN_PATH}
-
-cat << EOF > $TF_CLI_CONFIG_FILE
+cat << EOF > "$TF_CLI_CONFIG_FILE"
 provider_installation {
     filesystem_mirror {
         path    = "$WS_ROOT/dist/pkg_mirror"
@@ -21,13 +25,31 @@ provider_installation {
 }
 EOF
 
-USER_ORG=$( echo $NUODB_CP_USER | cut -d '/' -f 1 )
+# Invoke a command and record whether it failed
+check_err() {
+    if ! $@ ; then
+        errors="$errors\n* Command '$*' failed"
+    fi
+}
 
-$TERRAFORM_BIN init
-$TERRAFORM_BIN apply -auto-approve -var "org_name=${USER_ORG}"
+# Get organization from user name
+USER_ORG="${NUODB_CP_USER%/*}"
 
-exit_code=$( $TERRAFORM_BIN output exit )
+# Initialize Terraform workspace and apply configuration
+check_err "$TERRAFORM_BIN" init
+check_err "$TERRAFORM_BIN" apply -auto-approve -var "org_name=${USER_ORG}"
 
-$TERRAFORM_BIN destroy -auto-approve -var "org_name=${USER_ORG}"
+# Check that client application exited cleanly
+exit_code="$("$TERRAFORM_BIN" output -raw exit)"
+if [ "$exit_code" -ne 0 ]; then
+    errors="$errors\n* Unexpected exit code for application container: $exit_code"
+fi
 
-exit $exit_code
+# Destroy resources
+check_err "$TERRAFORM_BIN" destroy -auto-approve -var "org_name=${USER_ORG}"
+
+# Check that no errors occurred
+if [ -n "$errors" ]; then
+    printf "There were errors:$errors"
+    exit 1
+fi


### PR DESCRIPTION
This changes the end-to-end test that integrates with a client application to perform error checking on all Terraform commands, not just checking that the application had exit code 0.