### PR TITLE
Add validation to provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.21.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/oapi-codegen/runtime v1.1.1
+	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 )
 
 // Test dependencies

--- a/go.sum
+++ b/go.sum
@@ -393,6 +393,8 @@ github.com/hashicorp/terraform-plugin-docs v0.18.0 h1:2bINhzXc+yDeAcafurshCrIjtd
 github.com/hashicorp/terraform-plugin-docs v0.18.0/go.mod h1:iIUfaJpdUmpi+rI42Kgq+63jAjI8aZVTyxp3Bvk9Hg8=
 github.com/hashicorp/terraform-plugin-framework v1.5.0 h1:8kcvqJs/x6QyOFSdeAyEgsenVOUeC/IyKpi2ul4fjTg=
 github.com/hashicorp/terraform-plugin-framework v1.5.0/go.mod h1:6waavirukIlFpVpthbGd2PUNYaFedB0RwW3MDzJ/rtc=
+github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
+github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
 github.com/hashicorp/terraform-plugin-go v0.21.0 h1:VSjdVQYNDKR0l2pi3vsFK1PdMQrw6vGOshJXMNFeVc0=
 github.com/hashicorp/terraform-plugin-go v0.21.0/go.mod h1:piJp8UmO1uupCvC9/H74l2C6IyKG0rW4FDedIpwW5RQ=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=

--- a/internal/framework/schemas.go
+++ b/internal/framework/schemas.go
@@ -106,7 +106,7 @@ func GetStringValidators(oas *openapi3.Schema) []validator.String {
 
 	format := oas.Format
 	if format == "date-time" {
-		timestampPattern := "([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(([Zz])|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))"
+		timestampPattern := "^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(([Zz])|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))$"
 		validators = append(validators, stringvalidator.RegexMatches(regexp.MustCompile(timestampPattern), "must be a RFC 3339 date-time without fractional seconds"))
 	}
 

--- a/internal/framework/schemas.go
+++ b/internal/framework/schemas.go
@@ -8,12 +8,16 @@ package framework
 import (
 	"fmt"
 	"reflect"
+	"regexp"
+	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	datasource "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	resource "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/nuodb/terraform-provider-nuodbaas/openapi"
@@ -95,6 +99,28 @@ func IsSensitiveAttribute(oas *openapi3.Schema) bool {
 
 func IsImmutableAttribute(oas *openapi3.Schema) bool {
 	return IsExtensionSet(oas, "x-immutable")
+}
+
+func GetStringValidators(oas *openapi3.Schema) []validator.String {
+	var validators []validator.String
+
+	format := oas.Format
+	if format == "date-time" {
+		timestampPattern := "([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(([Zz])|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))"
+		validators = append(validators, stringvalidator.RegexMatches(regexp.MustCompile(timestampPattern), "must be a RFC 3339 date-time without fractional seconds"))
+	}
+
+	pattern := oas.Pattern
+	if pattern != "" {
+		if !strings.HasPrefix(pattern, "^") {
+			pattern = "^" + pattern
+		}
+		if !strings.HasSuffix(pattern, "$") {
+			pattern = pattern + "$"
+		}
+		validators = append(validators, stringvalidator.RegexMatches(regexp.MustCompile(pattern), "must match pattern: "+pattern))
+	}
+	return validators
 }
 
 func GetTerraformType(schemaRef *openapi3.SchemaRef) attr.Type {
@@ -253,6 +279,7 @@ func ToResourceAttribute(oas *openapi3.Schema, required, readOnly bool) (string,
 			Optional:            optional,
 			Computed:            computed,
 			Sensitive:           sensitive,
+			Validators:          GetStringValidators(oas),
 			PlanModifiers:       appendNonNil([]planmodifier.String{}, planmodifier.String(useStateForUnknown), planmodifier.String(requiresReplace)),
 		}
 	default:

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/nuodb/terraform-provider-nuodbaas/internal/provider/project"
 	"github.com/nuodb/terraform-provider-nuodbaas/openapi"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/providervalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -25,7 +26,8 @@ import (
 
 // Ensure NuoDbaasProvider satisfies various provider interfaces.
 var (
-	_ provider.Provider = &NuoDbaasProvider{}
+	_ provider.Provider                     = &NuoDbaasProvider{}
+	_ provider.ProviderWithConfigValidators = &NuoDbaasProvider{}
 )
 
 // NuoDbaasProvider defines the provider implementation.
@@ -219,5 +221,12 @@ func New(version string) func() provider.Provider {
 		return &NuoDbaasProvider{
 			version: version,
 		}
+	}
+}
+
+func (p *NuoDbaasProvider) ConfigValidators(context.Context) []provider.ConfigValidator {
+	return []provider.ConfigValidator{
+		providervalidator.RequiredTogether(path.MatchRoot("user"),
+			path.MatchRoot("password")),
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -226,7 +226,9 @@ func New(version string) func() provider.Provider {
 
 func (p *NuoDbaasProvider) ConfigValidators(context.Context) []provider.ConfigValidator {
 	return []provider.ConfigValidator{
-		providervalidator.RequiredTogether(path.MatchRoot("user"),
-			path.MatchRoot("password")),
+		providervalidator.RequiredTogether(
+			path.MatchRoot("user"),
+			path.MatchRoot("password"),
+		),
 	}
 }

--- a/internal/provider_test/suite_test.go
+++ b/internal/provider_test/suite_test.go
@@ -297,6 +297,10 @@ func (tf *TfHelper) ShowJson() ([]byte, error) {
 	return tf.Run("show", "-json")
 }
 
+func (tf *TfHelper) Validate() ([]byte, error) {
+	return tf.Run("validate")
+}
+
 func (tf *TfHelper) GetStateResources() ([]any, error) {
 	tfCopy := *tf
 	tfCopy.Silent = true


### PR DESCRIPTION
- For strings that have a pattern published in the OpenAPI spec, validate that the argument matches it.
- Add a regex check for `format: date-time`.
- Check that credentials in the provider configuration are all or nothing.

There are many other OpenAPI constraints that could be validated (number ranges, other formats, etc) but they are not used in our schema. They can be added as needed.