### PR TITLE
Stop using "prod" SLA in tests

### DIFF
--- a/internal/provider_test/integration_test.go
+++ b/internal/provider_test/integration_test.go
@@ -1011,7 +1011,7 @@ func TestImmutableAttributeChange(t *testing.T) {
 	// Change the project SLA and verify that a warning is displayed by
 	// Terraform when running `terraform plan`
 	t.Run("planSlaChange", func(t *testing.T) {
-		vars.project.Sla = "prod"
+		vars.project.Sla = "qa"
 		defer func() {
 			vars.project.Sla = "dev"
 		}()
@@ -1028,7 +1028,7 @@ func TestImmutableAttributeChange(t *testing.T) {
 	// Run `terraform apply` and verify that a warning is displayed by
 	// Terraform and that the request is also rejected by the server
 	t.Run("applySlaChangeRejected", func(t *testing.T) {
-		vars.project.Sla = "prod"
+		vars.project.Sla = "qa"
 		defer func() {
 			vars.project.Sla = "dev"
 		}()
@@ -1046,7 +1046,7 @@ func TestImmutableAttributeChange(t *testing.T) {
 	// destroy -target=...` followed by `terraform apply`
 	t.Run("applySlaChangeExplicitly", func(t *testing.T) {
 		// Change project SLA
-		vars.project.Sla = "prod"
+		vars.project.Sla = "qa"
 		tf.WriteConfigT(t, vars.builder.Build())
 
 		// Destroy the project and database
@@ -1071,12 +1071,12 @@ func TestImmutableAttributeChange(t *testing.T) {
 			HasAttribute("status.state").
 			HasAttribute("status.ready")
 		tf.CheckStateResource(t, "nuodbaas_project.proj").
-			HasAttributeValue("sla", "prod").
+			HasAttributeValue("sla", "qa").
 			HasAttributeValue("tier", "n0.nano").
 			HasAttribute("status.state").
 			HasAttribute("status.ready")
 		tf.CheckStateResource(t, "data.nuodbaas_project.proj").
-			HasAttributeValue("sla", "prod").
+			HasAttributeValue("sla", "qa").
 			HasAttributeValue("tier", "n0.nano").
 			HasAttribute("status.state").
 			HasAttribute("status.ready")

--- a/internal/provider_test/suite_test.go
+++ b/internal/provider_test/suite_test.go
@@ -605,8 +605,8 @@ type MockReconcilePolicy struct {
 // GetMockReconcilePolicy returns the current policy being used by the mock reconcilier for domain and database resources.
 func GetMockReconcilePolicy(t *testing.T) *MockReconcilePolicy {
 	cmd := exec.Command("kubectl", "get", "configmap", MOCK_OPERATOR_POLICY_CM, "-o", "jsonpath={.data}", "--ignore-not-found")
-	out, err := cmd.Output()
-	require.NoError(t, err, "Output %s", out)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "OUT ===\n%s\n===", out)
 
 	// If configmap does not exist, return nil
 	if strings.TrimSpace(string(out)) == "" {
@@ -633,8 +633,8 @@ func SetMockReconcilePolicy(t *testing.T, newPolicy MockReconcilePolicy) func() 
 	// Configmap exists, so patch it to have the supplied values
 	patch := fmt.Sprintf(PATCH_FMT, newPolicy.MarkAsReady, newPolicy.ReadinessDelaySeconds)
 	cmd := exec.Command("kubectl", "patch", "configmap", MOCK_OPERATOR_POLICY_CM, "--type=json", "-p", patch)
-	out, err := cmd.Output()
-	require.NoError(t, err, "Output %s", out)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "OUT ===\n%s\n===", out)
 	return func() { SetMockReconcilePolicy(t, *currentPolicy) }
 }
 

--- a/internal/provider_test/suite_test.go
+++ b/internal/provider_test/suite_test.go
@@ -606,7 +606,7 @@ type MockReconcilePolicy struct {
 func GetMockReconcilePolicy(t *testing.T) *MockReconcilePolicy {
 	cmd := exec.Command("kubectl", "get", "configmap", MOCK_OPERATOR_POLICY_CM, "-o", "jsonpath={.data}", "--ignore-not-found")
 	out, err := cmd.Output()
-	require.NoError(t, err)
+	require.NoError(t, err, "Output %s", out)
 
 	// If configmap does not exist, return nil
 	if strings.TrimSpace(string(out)) == "" {
@@ -633,8 +633,8 @@ func SetMockReconcilePolicy(t *testing.T, newPolicy MockReconcilePolicy) func() 
 	// Configmap exists, so patch it to have the supplied values
 	patch := fmt.Sprintf(PATCH_FMT, newPolicy.MarkAsReady, newPolicy.ReadinessDelaySeconds)
 	cmd := exec.Command("kubectl", "patch", "configmap", MOCK_OPERATOR_POLICY_CM, "--type=json", "-p", patch)
-	_, err := cmd.Output()
-	require.NoError(t, err)
+	out, err := cmd.Output()
+	require.NoError(t, err, "Output %s", out)
 	return func() { SetMockReconcilePolicy(t, *currentPolicy) }
 }
 


### PR DESCRIPTION
On DBaaS sandboxes, we have a resource quota not allowing any databases with `prod` SLA. Changed all references to `prod` SLA in the integration test to `qa`.