### PR TITLE
Add external test driver to use existing DBaaS cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,9 @@ workflows:
       - functional_tests:
           name: Functional tests (Minikube)
           test-driver: minikube
+      - functional_tests:
+          name: Functional tests (External DBaaS)
+          test-driver: external
       - check_quality:
           name: Static code checks
       - deploy_test:

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,6 @@ k8s-deps: $(KUBECTL) $(HELM)
 minikube-deps: $(MINIKUBE) k8s-deps
 
 .PHONY: external-deps
-external-deps: $(KUBECTL) $(HELM)
 
 setup-%: %-deps
 	mkdir -p $(OUTPUT_DIR) $(TMP_DIR)

--- a/Makefile
+++ b/Makefile
@@ -117,18 +117,21 @@ k8s-deps: $(KUBECTL) $(HELM)
 .PHONY: minikube-deps
 minikube-deps: $(MINIKUBE) k8s-deps
 
+.PHONY: external-deps
+external-deps: $(KUBECTL) $(HELM)
+
 setup-%: %-deps
 	mkdir -p $(OUTPUT_DIR) $(TMP_DIR)
-	./deploy/$*/setup.sh
+	[ ! -x "./deploy/$*/setup.sh" ] || ./deploy/$*/setup.sh
 
 env-%: %-deps
-	@./deploy/$*/env.sh
+	@[ ! -x "./deploy/$*/env.sh" ] || ./deploy/$*/env.sh
 
 logs-%: %-deps
-	./deploy/$*/logs.sh
+	[ ! -x "./deploy/$*/logs.sh" ] || ./deploy/$*/logs.sh
 
 teardown-%: %-deps
-	./deploy/$*/teardown.sh
+	[ ! -x "./deploy/$*/teardown.sh" ] || ./deploy/$*/teardown.sh
 
 .PHONY: testacc
 testacc: $(GOTESTSUM) $(TERRAFORM) ## Run acceptance tests

--- a/deploy/external/README.md
+++ b/deploy/external/README.md
@@ -1,0 +1,3 @@
+# External test driver
+
+The external test driver assumes that there is an existing DBaaS instance and simply exposes environment variables that allow the tests to use it.

--- a/deploy/external/env.sh
+++ b/deploy/external/env.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Set credentials supplied as CircleCI environment variables
+cat <<EOF
+export NUODB_CP_USER="$DBAAS_TEST_USER"
+export NUODB_CP_PASSWORD="$DBAAS_TEST_PASSWORD"
+export NUODB_CP_URL_BASE="$DBAAS_API_ENDPOINT"
+
+export CONTAINER_SCHEDULING_ENABLED="true"
+export WEBHOOKS_ENABLED="true"
+export ORGANIZATION_BOUND_USER="true"
+export TESTARGS="-short -tags shared_env"
+EOF

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -1,3 +1,4 @@
+// +build !shared_env
 // (C) Copyright 2013-2024 Dassault Systemes SE.  All Rights Reserved.
 //
 // This software is licensed under a BSD 3-Clause License.

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -1,4 +1,5 @@
-// +build !shared_env
+//go:build !shared_env
+
 // (C) Copyright 2013-2024 Dassault Systemes SE.  All Rights Reserved.
 //
 // This software is licensed under a BSD 3-Clause License.

--- a/internal/provider_test/integration_test.go
+++ b/internal/provider_test/integration_test.go
@@ -1286,7 +1286,15 @@ func TestDataSourceFiltering(t *testing.T) {
 		t.Skipf("Current user is bound to organization")
 	}
 
-	vars := newTestVars(true)
+	var vars testVars
+	vars.resetVars()
+	// Disable readiness checks
+	vars.providerCfg.Timeouts = map[string]framework.OperationTimeouts{
+		"default": {
+			Create: ptr("0"),
+			Update: ptr("0"),
+		},
+	}
 
 	// Create a projects and databases by directly invoking the REST service
 	client, err := vars.providerCfg.CreateClient()

--- a/internal/provider_test/integration_test.go
+++ b/internal/provider_test/integration_test.go
@@ -963,7 +963,7 @@ func TestNegative(t *testing.T) {
 		database := DatabaseResourceModel{
 			Organization: vars.project.Organization,
 			Project:      vars.project.Name,
-			Name:         withRandomSuffix("unmanaged"),
+			Name:         "unmanaged",
 			DbaPassword:  &dbaPassword,
 		}
 		err = database.Create(ctx, client)

--- a/internal/provider_test/suite_test.go
+++ b/internal/provider_test/suite_test.go
@@ -464,6 +464,23 @@ func (ac *AttributeChecker) ForEach(attributePath string, expectedCount int, ass
 	return ac
 }
 
+func (ac *AttributeChecker) HasListAttributeContaining(attributePath string, expected any) *AttributeChecker {
+	actual, err := FindChildNode(ac.resource, attributePath)
+	require.NoError(ac.t, err)
+	require.NotNil(ac.t, actual)
+
+	// Check that value is a list or slice
+	v := reflect.ValueOf(actual)
+	switch v.Kind() {
+	case reflect.Array, reflect.Slice:
+	default:
+		require.FailNow(ac.t, "Unexpected type: %T", actual)
+	}
+
+	require.Contains(ac.t, actual, expected, "Value not found at attribute path %s", attributePath)
+	return ac
+}
+
 // CreateTerraformWorkspace creates an empty directory to serve as a workspace for Terraform.
 func CreateTerraformWorkspace(t *testing.T) *TfHelper {
 	projectRoot := GetProjectRoot(t)


### PR DESCRIPTION
This change allows the Terraform tests to be run against the DBaaS dev cluster by adding the external test driver and configuring CircleCI to run a variant of the test job against it. Several changes are made to avoid collisions between concurrent users.

- Make the project name unique by adding a random suffix.
- Resolve the organization from the user name. This is necessary because the circleci/test user is limited to its own organization.
- Introduce the `shared_env` build tag that prevents the examples tests from running when set. The examples tests use hard-coded resource names, so they would generate collisions when multiple runs are concurrently executing against the same environment.
- Change asserts to check for the presence of values in a list, without assuming the size of the list.