### PR TITLE
Add token authentication to Terraform provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ KUBECTL_VERSION ?= 1.28.3
 KWOKCTL_VERSION ?= 0.5.1
 HELM_VERSION ?= 3.14.3
 MINIKUBE_VERSION ?= 1.32.0
+NUODB_CP_VERSION ?= 2.5.0
 
 GOTESTSUM := bin/gotestsum
 TFPLUGINDOCS := bin/tfplugindocs
@@ -23,6 +24,7 @@ KWOKCTL := bin/kwokctl
 HELM := bin/helm
 MINIKUBE := bin/minikube
 GOLANGCI_LINT := bin/golangci-lint
+NUODB_CP := bin/nuodb-cp
 
 PUBLISH_VERSION ?= 1.0.0
 PUBLISH_DIR ?= $(PROJECT_DIR)/dist
@@ -74,6 +76,11 @@ $(MINIKUBE):
 	curl -L -s https://storage.googleapis.com/minikube/releases/v$(MINIKUBE_VERSION)/minikube-$(OS)-$(ARCH) -o $(MINIKUBE)
 	chmod +x $(MINIKUBE)
 
+$(NUODB_CP):
+	mkdir -p bin
+	curl -L -s https://github.com/nuodb/nuodb-cp-releases/releases/download/v$(NUODB_CP_VERSION)/nuodb-cp -o $(NUODB_CP)
+	chmod +x $(NUODB_CP)
+
 bin/%:
 	$(MAKE) install-tools
 
@@ -112,7 +119,7 @@ lint: $(GOLANGCI_LINT) ## Run linters to check code quality and find for common 
 kwok-deps: $(KWOKCTL) $(KUBECTL) $(HELM)
 
 .PHONY: k8s-deps
-k8s-deps: $(KUBECTL) $(HELM)
+k8s-deps: $(KUBECTL) $(HELM) $(NUODB_CP)
 
 .PHONY: minikube-deps
 minikube-deps: $(MINIKUBE) k8s-deps

--- a/deploy/k8s/env.sh
+++ b/deploy/k8s/env.sh
@@ -16,9 +16,9 @@ export NUODB_CP_USER=system/admin
 export NUODB_CP_PASSWORD="$(kubectl get secret dbaas-user-system-admin -o jsonpath='{.data.password}' | base64 -d)"
 
 # Use token authentication if server is configured to generate tokens
-if [ ! "$(kubectl get secrets nuodb-cp-runtime-config -o jsonpath='{.data.secretPassword}' --ignore-not-found)" = "" ]; then
+if [ -n "$(kubectl get secrets nuodb-cp-runtime-config -o jsonpath='{.data.secretPassword}' --ignore-not-found)" ]; then
     NUODB_CP_TOKEN="$(nuodb-cp httpclient POST login --jsonpath token --unquote)"
-    if [ ! "$NUODB_CP_TOKEN" = "" ]; then
+    if [ -n "$NUODB_CP_TOKEN" ]; then
         unset NUODB_CP_USER
         unset NUODB_CP_PASSWORD
     fi

--- a/deploy/k8s/env.sh
+++ b/deploy/k8s/env.sh
@@ -11,14 +11,24 @@ hostname="$(kubectl get service ingress-nginx-controller -o jsonpath='{.status.l
 port="$(kubectl get service ingress-nginx-controller -o jsonpath='{.spec.ports[?(@.appProtocol=="http")].port}')"
 
 # Get password for system/admin user generate by `helm install`
-NUODB_CP_URL_BASE="http://$hostname:$port/nuodb-cp"
-NUODB_CP_USER=system/admin
-NUODB_CP_PASSWORD="$(kubectl get secret dbaas-user-system-admin -o jsonpath='{.data.password}' | base64 -d)"
+export NUODB_CP_URL_BASE="http://$hostname:$port/nuodb-cp"
+export NUODB_CP_USER=system/admin
+export NUODB_CP_PASSWORD="$(kubectl get secret dbaas-user-system-admin -o jsonpath='{.data.password}' | base64 -d)"
+
+# Use token authentication if server is configured to generate tokens
+if [ ! "$(kubectl get secrets nuodb-cp-runtime-config -o jsonpath='{.data.secretPassword}' --ignore-not-found)" = "" ]; then
+    NUODB_CP_TOKEN="$(nuodb-cp httpclient POST login --jsonpath token --unquote)"
+    if [ ! "$NUODB_CP_TOKEN" = "" ]; then
+        unset NUODB_CP_USER
+        unset NUODB_CP_PASSWORD
+    fi
+fi
 
 cat <<EOF
 export NUODB_CP_URL_BASE="$NUODB_CP_URL_BASE"
 export NUODB_CP_USER="$NUODB_CP_USER"
 export NUODB_CP_PASSWORD="$NUODB_CP_PASSWORD"
+export NUODB_CP_TOKEN="$NUODB_CP_TOKEN"
 
 export PAUSE_OPERATOR_COMMAND="$(pwd)/pause-operator.sh"
 export RESUME_OPERATOR_COMMAND="$(pwd)/resume-operator.sh"

--- a/deploy/k8s/teardown.sh
+++ b/deploy/k8s/teardown.sh
@@ -9,6 +9,13 @@ if [ "$IGNORE_NOT_FOUND" = true ]; then
 fi
 
 echo "Deleting Control Plane resources..."
+# Delete databases before domains
+kubectl get databases.cp.nuodb.com -o name | xargs -r kubectl delete --ignore-not-found
+kubectl get domains.cp.nuodb.com -o name | xargs -r kubectl delete --ignore-not-found
+# Delete service tiers before Helm features
+kubectl get servicetiers.cp.nuodb.com -o name | xargs -r kubectl delete --ignore-not-found
+kubectl get helmfeatures.cp.nuodb.com -o name | xargs -r kubectl delete --ignore-not-found
+# Delete any other NuoDB CP resources
 for crd in $(kubectl get crd -o name | sed -n 's|.*/\(.*\.cp\.nuodb\.com\)|\1|p'); do
     kubectl get "$crd" -o name | xargs -r kubectl delete
 done

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,6 +77,7 @@ data "nuodbaas_database" "database_details" {
 - `password` (String, Sensitive) The password for the user. If not specified, defaults to the value of the `NUODB_CP_PASSWORD` environment variable.
 - `skip_verify` (Boolean) Whether to skip server certificate verification. If not specified, defaults to the value of the `NUODB_CP_SKIP_VERIFY` environment variable.
 - `timeouts` (Attributes Map) Timeouts by resource type and operation. A resource type of `default` is used to supply timeouts for all resources that are not specified explicitly. (see [below for nested schema](#nestedatt--timeouts))
+- `token` (String, Sensitive) The token to use to authenticate the user. If not specified, defaults to the value of the `NUODB_CP_TOKEN` environment variable.
 - `url_base` (String) The base URL for the server, including the protocol. If not specified, defaults to the value of the `NUODB_CP_URL_BASE` environment variable.
 - `user` (String) The name of the user in the format `<organization>/<user>`. If not specified, defaults to the value of the `NUODB_CP_USER` environment variable.
 

--- a/examples/utils.go
+++ b/examples/utils.go
@@ -26,13 +26,14 @@ const (
 func DefaultApiClient() (*openapi.Client, error) {
 	user := os.Getenv("NUODB_CP_USER")
 	password := os.Getenv("NUODB_CP_PASSWORD")
+	token := os.Getenv("NUODB_CP_TOKEN")
 	urlBase := os.Getenv("NUODB_CP_URL_BASE")
 
 	if urlBase == "" {
 		urlBase = DEFAULT_URL
 	}
 
-	return nuodbaas_client.NewApiClient(urlBase, user, password, true)
+	return nuodbaas_client.NewApiClient(urlBase, user, password, token, true)
 }
 
 func CreateProject(t *testing.T, ctx context.Context, client *openapi.Client, organization string, name string, sla string, tier string) error {

--- a/internal/client/dbaas_client.go
+++ b/internal/client/dbaas_client.go
@@ -13,17 +13,21 @@ import (
 	"github.com/nuodb/terraform-provider-nuodbaas/openapi"
 )
 
-func WithBasicCredentials(user, password string) openapi.ClientOption {
+// WithCredentials injects either basic or bearer credentials into request, with
+// precedence given to bearer authentication if a token is supplied.
+func WithCredentials(user, password, token string) openapi.ClientOption {
 	return openapi.WithRequestEditorFn(func(_ context.Context, req *http.Request) error {
-		if user != "" {
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		} else if user != "" {
 			req.SetBasicAuth(user, password)
 		}
 		return nil
 	})
 }
 
-func NewApiClient(urlBase string, user string, password string, skipVerify bool) (*openapi.Client, error) {
-	client, err := openapi.NewClient(urlBase, WithBasicCredentials(user, password))
+func NewApiClient(urlBase string, user string, password string, token string, skipVerify bool) (*openapi.Client, error) {
+	client, err := openapi.NewClient(urlBase, WithCredentials(user, password, token))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change adds token authentication to the Terraform provider and enables token authentication on test runs where the server is configured to generate tokens.