### PR TITLE
Allow OpenAPI description overrides and fix dba_password description

### DIFF
--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -53,7 +53,7 @@ resource "nuodbaas_database" "db" {
 
 ### Optional
 
-- `dba_password` (String, Sensitive) The password for the DBA user. Can only be specified when creating a database.
+- `dba_password` (String, Sensitive) The password for the DBA user
 - `labels` (Map of String) User-defined labels attached to the resource that can be used for filtering
 - `maintenance` (Attributes) (see [below for nested schema](#nestedatt--maintenance))
 - `properties` (Attributes) (see [below for nested schema](#nestedatt--properties))

--- a/internal/provider/database/resource.go
+++ b/internal/provider/database/resource.go
@@ -190,7 +190,8 @@ func (state *DatabaseResourceModel) SetId(id string) error {
 }
 
 func GetDatabaseResourceAttributes() (map[string]schema.Attribute, error) {
-	return framework.GetResourceAttributes("DatabaseCreateUpdateModel")
+	return framework.GetResourceAttributes("DatabaseCreateUpdateModel",
+		framework.WithDescription("dbaPassword", "The password for the DBA user"))
 }
 
 func NewDatabaseResourceState() framework.ResourceState {


### PR DESCRIPTION
The OpenAPI spec correctly says that the `dbaPassword` field can only supplied when creating a database using `PUT /databases/org/proj/db`, but since Terraform automatically invokes `POST
/databases/org/proj/db/dbaPassword` when it detects changes to `dba_password`, this description is not relevant to the `dba_password` attribute.

This change allows overrides to be defined on OpenAPI schema properties and specifies an override on the `dbaPassword` property, which is used for the `dba_password` Terraform attribute.