### PR TITLE
Add testing using OpenTofu

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,11 +73,18 @@ jobs:
 
   functional_tests_kwok_dev:
     executor: ubuntu_vm
+    parameters:
+      use-tofu:
+        description: |
+          Whether to use OpenTofu.
+        type: boolean
+        default: false
     environment:
       IMG_REPO: nuodb/nuodb-control-plane
       IMG_TAG: latest
       NUODB_CP_IMAGE: nuodb/nuodb-control-plane:latest
       USING_LATEST_API: "true"
+      USE_TOFU: "<< parameters.use-tofu >>"
     steps:
       - checkout
       - add_ssh_keys:
@@ -122,6 +129,9 @@ jobs:
 workflows:
   test:
     jobs:
+      - functional_tests_kwok_dev:
+          name: Functional tests (KWOK, dev, OpenTofu)
+          use-tofu: true
       - functional_tests_kwok_dev:
           name: Functional tests (KWOK, dev)
       - functional_tests:

--- a/internal/provider_test/backups_test.go
+++ b/internal/provider_test/backups_test.go
@@ -39,7 +39,7 @@ func skipIfBackupPoliciesNotSupported(t *testing.T, ctx context.Context, client 
 		ListAccessible: ptr(true),
 	})
 	// GET /backuppolicies?listAccessible=true should not return 404 if supported
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		t.Skip("Server does not have /backuppolicies resource")
 	}
 	// Make sure some other error did not occur

--- a/internal/provider_test/integration_test.go
+++ b/internal/provider_test/integration_test.go
@@ -896,7 +896,11 @@ func TestNegative(t *testing.T) {
 	// Try to import resource already being managed
 	out, err = tf.Run("import", "nuodbaas_database.db", vars.project.Organization+"/"+vars.project.Name+"/db")
 	require.Error(t, err)
-	require.Contains(t, string(out), "Resource already managed by Terraform")
+	tfName := "Terraform"
+	if USE_TOFU.IsTrue() {
+		tfName = "OpenTofu"
+	}
+	require.Contains(t, string(out), "Resource already managed by "+tfName)
 
 	t.Run("invalidProviderConfiguration", func(t *testing.T) {
 		// Clear any credentials set via environment variables


### PR DESCRIPTION
- Add make target to download tofu binary.
- Add test option USE_TOFU to allow OpenTofu to be used.
- Add CircleCI workflow that runs tests with OpenTofu.
- Log command output if non-0 exit code is returned even if silent is set to true.
- Fix an issue with detection of unsupported /backuppolicies APIs, which fails without an HTTP response if unable to connect to the server.