### PR TITLE
Improve polling loop for readiness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ commands:
           name: "Run tests"
           command: |
             make testacc
+          no_output_timeout: 30m
       - run:
           name: "Generate coverage report"
           command: |
@@ -66,6 +67,8 @@ jobs:
     executor: ubuntu_vm
     environment:
       NUODB_CP_VERSION: << parameters.nuodb-cp-version >>
+      TF_LOG: DEBUG
+      TF_LOG_PATH: /tmp/test-artifacts/tf-debug.log
     steps:
       - checkout
       - run_test:
@@ -85,6 +88,8 @@ jobs:
       NUODB_CP_IMAGE: nuodb/nuodb-control-plane:latest
       USING_LATEST_API: "true"
       USE_TOFU: "<< parameters.use-tofu >>"
+      TF_LOG: DEBUG
+      TF_LOG_PATH: /tmp/test-artifacts/tf-debug.log
     steps:
       - checkout
       - add_ssh_keys:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nuodb/terraform-provider-nuodbaas
 go 1.19
 
 require (
+	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/deepmap/oapi-codegen/v2 v2.1.0
 	github.com/getkin/kin-openapi v0.123.0
 	github.com/hashicorp/terraform-plugin-docs v0.18.0
@@ -95,7 +96,6 @@ require (
 	github.com/GaijinEntertainment/go-exhaustruct/v3 v3.1.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
-	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/OpenPeeDeeP/depguard/v2 v2.1.0 // indirect
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.1-proton // indirect

--- a/internal/framework/generic_resource.go
+++ b/internal/framework/generic_resource.go
@@ -313,15 +313,15 @@ func (r *GenericResource) GetTimeout(operation string, defaultTimeout time.Durat
 	return defaultTimeout
 }
 
-type resourceFailed struct {
+type resourceFailedError struct {
 	message string
 }
 
 func ResourceFailed(format string, args ...any) error {
-	return &resourceFailed{message: fmt.Sprintf(format, args...)}
+	return &resourceFailedError{message: fmt.Sprintf(format, args...)}
 }
 
-func (err *resourceFailed) Error() string {
+func (err *resourceFailedError) Error() string {
 	return err.message
 }
 
@@ -350,7 +350,7 @@ func (r *GenericResource) AwaitReady(ctx context.Context, state ResourceState, o
 			return nil
 		}
 		// Return early if resource in failed state for several iterations
-		if _, ok := readyErr.(*resourceFailed); ok {
+		if _, ok := readyErr.(*resourceFailedError); ok {
 			consecutiveFailed++
 			if consecutiveFailed >= FAILURE_THRESHOLD {
 				return readyErr

--- a/internal/framework/generic_resource.go
+++ b/internal/framework/generic_resource.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -235,6 +237,7 @@ const (
 	READINESS_TIMEOUT = 10 * time.Minute
 	DELETION_TIMEOUT  = 1 * time.Minute
 	POLLING_INTERVAL  = 5 * time.Second
+	FAILURE_THRESHOLD = 3
 	DEFAULT_RESOURCE  = "default"
 	CREATE_OPERATION  = "create"
 	UPDATE_OPERATION  = "update"
@@ -310,6 +313,26 @@ func (r *GenericResource) GetTimeout(operation string, defaultTimeout time.Durat
 	return defaultTimeout
 }
 
+type resourceFailed struct {
+	message string
+}
+
+func ResourceFailed(format string, args ...any) error {
+	return &resourceFailed{message: fmt.Sprintf(format, args...)}
+}
+
+func (err *resourceFailed) Error() string {
+	return err.message
+}
+
+func isNetworkError(err error) bool {
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	urlErr, ok := err.(*url.Error)
+	return ok && urlErr.Temporary()
+}
+
 func (r *GenericResource) AwaitReady(ctx context.Context, state ResourceState, operation string) error {
 	timeout := r.GetTimeout(operation, READINESS_TIMEOUT)
 	if timeout == 0 {
@@ -317,6 +340,7 @@ func (r *GenericResource) AwaitReady(ctx context.Context, state ResourceState, o
 			map[string]any{"resourceType": r.TypeName, "operation": operation})
 		return nil
 	}
+	consecutiveFailed := 0
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	for {
@@ -324,6 +348,15 @@ func (r *GenericResource) AwaitReady(ctx context.Context, state ResourceState, o
 		readyErr := state.CheckReady(ctx, r.client.Client)
 		if readyErr == nil {
 			return nil
+		}
+		// Return early if resource in failed state for several iterations
+		if _, ok := readyErr.(*resourceFailed); ok {
+			consecutiveFailed++
+			if consecutiveFailed >= FAILURE_THRESHOLD {
+				return readyErr
+			}
+		} else {
+			consecutiveFailed = 0
 		}
 		time.Sleep(POLLING_INTERVAL)
 
@@ -333,8 +366,13 @@ func (r *GenericResource) AwaitReady(ctx context.Context, state ResourceState, o
 			if os.IsTimeout(err) && ctx.Err() == context.DeadlineExceeded {
 				return fmt.Errorf("Timed out after %s: %s", timeout, readyErr.Error())
 			}
-			// Return verbatim error if not timeout
-			return err
+			// Suppress network errors, which may be transient and retriable
+			if isNetworkError(err) {
+				tflog.Info(ctx, "Suppressing network error while awaiting readiness",
+					map[string]any{"resourceType": r.TypeName, "error": err.Error()})
+			} else {
+				return err
+			}
 		}
 	}
 }
@@ -356,7 +394,16 @@ func (r *GenericResource) AwaitDeleted(ctx context.Context, state ResourceState)
 			if helper.IsNotFound(err) {
 				return nil
 			}
-			return err
+			if os.IsTimeout(err) && ctx.Err() == context.DeadlineExceeded {
+				return fmt.Errorf("Timed out after %s", timeout)
+			}
+			// Suppress network errors, which may be transient and retriable
+			if isNetworkError(err) {
+				tflog.Info(ctx, "Suppressing network error while awaiting deletion",
+					map[string]any{"resourceType": r.TypeName, "error": err.Error()})
+			} else {
+				return err
+			}
 		}
 
 		time.Sleep(POLLING_INTERVAL)


### PR DESCRIPTION
- Exit polling loop early if resource is in Failed state for several iterations. We have to use a failure threshold because the resource may appear as Failed immediately after a configuration change that should eventually return it to a healthy state, since reconciliation is asynchronous.
- Suppress network errors in polling loop.
- Collect Terraform logging.