### PR TITLE
Bump version to 1.3.0 and add scripting to keep it synchronized

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,7 @@ before:
     # Make sure generated code is up-to-date before publishing.
     - make generate
     - make check-no-changes
+    - make check-version
 builds:
 - env:
     # goreleaser does not work with CGO, it could also complicate

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     nuodbaas = {
       source  = "registry.terraform.io/nuodb/nuodbaas"
-      version = "1.2.0"
+      version = "1.3.0"
     }
   }
 }

--- a/examples/provider/.gitignore
+++ b/examples/provider/.gitignore
@@ -1,0 +1,2 @@
+# provider.tf is generated from provider.tf.tmpl
+provider.tf

--- a/examples/provider/provider.tf.tmpl
+++ b/examples/provider/provider.tf.tmpl
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     nuodbaas = {
       source  = "registry.terraform.io/nuodb/nuodbaas"
-      version = "1.2.0"
+      version = "{{ version }}"
     }
   }
 }

--- a/get-version.sh
+++ b/get-version.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Scrape the version from the main.go file so that we do not specify the same
+# value in multiple places.
+cd "$(dirname "$0")"
+sed -n 's|^\t*version string *= "\([^"]*\)" // {{version}}|\1|p' main.go

--- a/inject-version.sh
+++ b/inject-version.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Inject current version into example provider configuration
+cd "$(dirname "$0")"
+version="$(./get-version.sh)"
+file=examples/provider/provider.tf
+sed "s/{{ version }}/$version/" "$file.tmpl" > "$file"

--- a/main.go
+++ b/main.go
@@ -20,6 +20,9 @@ import (
 //go:generate bin/oapi-codegen -config oapi-codegen.yaml -generate client -o openapi/client.go openapi.yaml
 //go:generate bin/oapi-codegen -config oapi-codegen.yaml -generate spec -o openapi/spec.go openapi.yaml
 
+// Inject current version into examples:
+//go:generate ./inject-version.sh
+
 // Format Terraform examples:
 //go:generate bin/terraform fmt -recursive ./examples/
 
@@ -27,12 +30,13 @@ import (
 //go:generate bin/tfplugindocs generate --provider-name nuodbaas
 
 var (
-	// This will be overridden by the version from the Git tag when GoReleaser
-	// creates an actual release. `{{version}}` in the comment is a marker to
-	// enable scraping of the version when running `make package`.
+	// The version from the Git tag is used by GoReleaser when publishing a
+	// release, but the release job is conditionalized on the Git tag matching
+	// the version in the code. `{{version}}` in the comment is a marker to
+	// enable scraping of the version.
 	//
 	// For more information on GoReleaser, see https://goreleaser.com/cookbooks/using-main.version/
-	version string = "1.2.0" // {{version}}
+	version string = "1.3.0" // {{version}}
 )
 
 func main() {


### PR DESCRIPTION
- Bump version to 1.3.0 in preparation for release.
- Add scripting to keep the version in the code consistent with the examples and with the Git tag used to trigger a release.