### PR TITLE
Add overrides to database schema to require full backup name

### DIFF
--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -88,7 +88,7 @@ Optional:
 
 Optional:
 
-- `backup` (String) The name of the backup to restore the database from. If a fully-qualified name is not supplied, then the organization, project, or name of the database being created is assumed.
+- `backup` (String) The fully-qualified name of the backup to restore the database from
 
 
 <a id="nestedatt--status"></a>

--- a/internal/provider/database/resource.go
+++ b/internal/provider/database/resource.go
@@ -206,7 +206,12 @@ func (state *DatabaseResourceModel) GetEventPath() string {
 
 func GetDatabaseResourceAttributes() (map[string]schema.Attribute, error) {
 	return framework.GetResourceAttributes("DatabaseCreateUpdateModel",
-		framework.WithDescription("dbaPassword", "The password for the DBA user"))
+		// DBA password can be updated from configuration, so remove note about it only being accepted on create
+		framework.WithDescription("dbaPassword", "The password for the DBA user"),
+		// Require fully-qualified backup name to prevent normalization from causing Terraform to fail due to change in attribute value
+		framework.WithDescription("restoreFrom.backup", "The fully-qualified name of the backup to restore the database from"),
+		framework.WithPattern("restoreFrom.backup", "([a-z][a-z0-9]*/){3}([0-9]+|[a-z][a-z0-9]*)"),
+	)
 }
 
 func NewDatabaseResourceState() framework.ResourceState {

--- a/internal/provider_test/integration_test.go
+++ b/internal/provider_test/integration_test.go
@@ -1784,7 +1784,7 @@ func TestValidation(t *testing.T) {
 		tf.WriteConfigT(t, vars.builder.Build())
 
 		// Run `terraform validate`
-		out, err = tf.Validate()
+		_, err = tf.Validate()
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
Terraform fails when it detects changes to configuration values, even if the change is to an equivalent form. This occurs when a partial backup name is supplied, which is normalized by the server to resolve missing path components from the database.

To avoid Terraform errors, require the `restore_from.backup` attribute to specify the fully-qualified name.