### PR TITLE
Run external DBaaS tests using self-hosted runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,22 @@ executors:
     # Check https://circleci.com/developer/images/image/cimg/go for more details
     docker:
       - image: cimg/go:1.23.1
-    resource_class: small
+    resource_class: << parameters.resource_class >>
+    parameters:
+      resource_class:
+        default: small
+        description: The resource class for this executor
+        type: string
 
   ubuntu_vm:
     machine:
       image: ubuntu-2404:2024.05.1
-    resource_class: medium
+    resource_class: << parameters.resource_class >>
+    parameters:
+      resource_class:
+        default: medium
+        description: The resource class for this executor
+        type: string
 
 commands:
   run_test:
@@ -64,7 +74,19 @@ jobs:
           The version of the NuoDB Control Plane to test against.
         type: string
         default: 2.7.0
-    executor: ubuntu_vm
+      executor-name:
+        description: |
+          The name of the executor.
+        type: string
+        default: ubuntu_vm
+      executor-resource-class:
+        description: |
+          The executor resource class
+        type: string
+        default: medium
+    executor: 
+      name: << parameters.executor-name >>
+      resource_class: << parameters.executor-resource-class >>
     environment:
       NUODB_CP_VERSION: << parameters.nuodb-cp-version >>
       TF_LOG: DEBUG
@@ -119,9 +141,16 @@ jobs:
           command: make lint
 
   deploy_test:
-    executor: ubuntu_vm
+    executor: 
+      name: go
+      resource_class: nuodb/orca-internal
     steps:
      - checkout
+     - run:
+        name: Install dependencies
+        command: |
+          sudo apt-get update \
+            && sudo apt-get install python3 python3-venv python3-pip
      - run:
         name: "Run end to end deployment test"
         command: |
@@ -156,6 +185,8 @@ workflows:
       - functional_tests:
           name: Functional tests (External DBaaS)
           test-driver: external
+          executor-name: go
+          executor-resource-class: nuodb/orca-internal
       - check_quality:
           name: Static code checks
       - deploy_test:

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ website/node_modules
 *.iml
 **/variable.tf
 test-results/
+test/app/.venv
 
 website/vendor
 

--- a/test/app/app.tf
+++ b/test/app/app.tf
@@ -1,28 +1,14 @@
-resource "docker_container" "dbapp" {
-  name  = "dbapp"
-  image = "python:3.12.2-alpine3.19"
-  env = [ 
-    "DB_NAME=${nuodbaas_database.app.name}",
-    "DB_USER=dba",
-    "DB_PASSWORD=${var.dba_password}",
-    "PEER_ADDRESS=${nuodbaas_database.app.status.sql_endpoint}:443",
-    "CA_CERT=${nuodbaas_database.app.status.ca_pem}"
-    ]
-  mounts {
-    type = "bind"
-    target = "/usr/src/dbapp"
-    source = "${path.cwd}"
+resource "terraform_data" "dbapp" {
+
+  provisioner "local-exec" {
+    command = "./db_connect.sh"
+
+    environment = {
+      DB_NAME      = nuodbaas_database.app.name
+      DB_USER      = "dba"
+      DB_PASSWORD  = var.dba_password
+      PEER_ADDRESS = "${nuodbaas_database.app.status.sql_endpoint}:443"
+      CA_CERT      = nuodbaas_database.app.status.ca_pem
+    }
   }
-  command = [ "/usr/src/dbapp/db_connect.sh" ]
-  must_run = false
-  attach = true
-  logs = true
-}
-
-output "exit" {
-  value = docker_container.dbapp.exit_code
-}
-
-output "logs" {
-  value = docker_container.dbapp.container_logs
 }

--- a/test/app/db_connect.sh
+++ b/test/app/db_connect.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env sh
 
-pip3 install pynuodb
+set -e
 
-python3 /usr/src/dbapp/db_connect.py
+# Setup Python virtual environment
+python3 -m venv .venv
+. .venv/bin/activate
+pip3 install -r requirements.txt
+
+python3 db_connect.py

--- a/test/app/providers.tf
+++ b/test/app/providers.tf
@@ -1,23 +1,17 @@
 terraform {
   required_providers {
     nuodbaas = {
-      source  = "registry.terraform.io/nuodb/nuodbaas"
-    }
-    docker = {
-      source  = "kreuzwerker/docker"
-      version = "3.0.2"
+      source = "registry.terraform.io/nuodb/nuodbaas"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
       version = "3.6.0"
     }
   }
 }
 
 # Used to generate unique project name to avoid collisions
-provider "random" { }
-
-provider "docker" { }
+provider "random" {}
 
 provider "nuodbaas" {
   # Don't wait for the project to be created to proceed with creating other resources.

--- a/test/app/requirements.txt
+++ b/test/app/requirements.txt
@@ -1,0 +1,3 @@
+ipaddress==1.0.23
+pynuodb==3.0.0
+pytz==2024.2

--- a/test/app/run.sh
+++ b/test/app/run.sh
@@ -41,12 +41,6 @@ export TF_VAR_org_name="${NUODB_CP_USER%/*}"
 check_err "$TERRAFORM" init
 check_err "$TERRAFORM" apply -auto-approve
 
-# Check that client application exited cleanly
-exit_code="$("$TERRAFORM" output -raw exit)"
-if [ "$exit_code" -ne 0 ]; then
-    errors="$errors\n* Unexpected exit code for application container: $exit_code"
-fi
-
 # Destroy resources
 check_err "$TERRAFORM" destroy -auto-approve
 


### PR DESCRIPTION
**Changes**

- Refactor the app E2E test so that it does not require a machine runner.  Use `local-exec` provisioned to run the _dbapp_ locally which requires python3.
- Change CircleCI config so that tests targeting external DBaaS run on a self-hosted runner
